### PR TITLE
feat: custom domain, Giscus, Renovate, firmware-watch PRs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Build site
         run: pnpm --filter la-mesh-site build
-        env:
-          DOCS_BASE_PATH: /LA-Mesh
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/firmware-watch.yml
+++ b/.github/workflows/firmware-watch.yml
@@ -2,9 +2,13 @@ name: Firmware Watch
 
 on:
   schedule:
-    # Check daily at 08:00 UTC
-    - cron: '0 8 * * *'
+    # Check weekly on Monday at 08:00 UTC
+    - cron: '0 8 * * 1'
   workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   check-meshtastic:
@@ -17,83 +21,187 @@ jobs:
         id: pinned
         run: |
           VERSION=$(jq -r '.meshtastic.version' firmware/manifest.json)
+          VERSION_FULL=$(jq -r '.meshtastic.version_full' firmware/manifest.json)
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_full=$VERSION_FULL" >> "$GITHUB_OUTPUT"
 
       - name: Get latest release
         id: latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST=$(gh api repos/meshtastic/firmware/releases/latest --jq '.tag_name' | sed 's/^v//')
-          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          TAG=$(gh api repos/meshtastic/firmware/releases/latest --jq '.tag_name')
+          FULL="${TAG#v}"
+          SHORT=$(echo "$FULL" | grep -oP '^\d+\.\d+\.\d+')
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$SHORT" >> "$GITHUB_OUTPUT"
+          echo "version_full=$FULL" >> "$GITHUB_OUTPUT"
 
           NOTES=$(gh api repos/meshtastic/firmware/releases/latest --jq '.body' | head -50)
-          # Write notes to file to avoid shell escaping issues
           echo "$NOTES" > /tmp/release-notes.txt
 
       - name: Compare versions
-        if: steps.pinned.outputs.version != steps.latest.outputs.version
+        id: compare
+        run: |
+          if [ "${{ steps.pinned.outputs.version }}" != "${{ steps.latest.outputs.version }}" ]; then
+            echo "update=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "update=false" >> "$GITHUB_OUTPUT"
+            echo "Firmware is up to date (v${{ steps.pinned.outputs.version }})"
+          fi
+
+      - name: Create version-bump PR
+        if: steps.compare.outputs.update == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PINNED: ${{ steps.pinned.outputs.version }}
+          PINNED_FULL: ${{ steps.pinned.outputs.version_full }}
+          LATEST: ${{ steps.latest.outputs.version }}
+          LATEST_FULL: ${{ steps.latest.outputs.version_full }}
+          LATEST_TAG: ${{ steps.latest.outputs.tag }}
+        run: |
+          BRANCH="firmware-update/v${LATEST}"
+
+          # Check if PR already exists for this version
+          EXISTING_PR=$(gh pr list --search "firmware: update Meshtastic v${LATEST}" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+            echo "PR #$EXISTING_PR already exists for v${LATEST}, skipping."
+            exit 0
+          fi
+
+          # Configure git identity
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Create branch
+          git checkout -b "$BRANCH"
+
+          # Update manifest.json with jq
+          MANIFEST="firmware/manifest.json"
+
+          # Read device keys from manifest
+          DEVICES=$(jq -r '.meshtastic.devices | keys[]' "$MANIFEST")
+
+          # Build jq update expression for version fields
+          jq --arg ver "$LATEST" \
+             --arg ver_full "$LATEST_FULL" \
+             --arg tag "$LATEST_TAG" \
+             --arg date "$(date -u +%Y-%m-%d)" \
+             '
+             .last_updated = $date |
+             .meshtastic.version = $ver |
+             .meshtastic.version_full = $ver_full |
+             .meshtastic.min_version = $ver |
+             .meshtastic.release_notes = "https://github.com/meshtastic/firmware/releases/tag/\($tag)"
+             ' "$MANIFEST" > "${MANIFEST}.tmp"
+          mv "${MANIFEST}.tmp" "$MANIFEST"
+
+          # Update binary/littlefs filenames per device
+          for DEVICE in $DEVICES; do
+            jq --arg dev "$DEVICE" \
+               --arg ver_full "$LATEST_FULL" \
+               '
+               .meshtastic.devices[$dev].binary = "firmware-\($dev)-\($ver_full).bin" |
+               .meshtastic.devices[$dev].littlefs = "littlefs-\($dev)-\($ver_full).bin" |
+               .meshtastic.devices[$dev].sha256 = "UPDATE_AFTER_DOWNLOAD"
+               ' "$MANIFEST" > "${MANIFEST}.tmp"
+            mv "${MANIFEST}.tmp" "$MANIFEST"
+          done
+
+          git add "$MANIFEST"
+          git commit -m "firmware: bump Meshtastic v${PINNED} -> v${LATEST}"
+          git push origin "$BRANCH"
+
+          NOTES=$(cat /tmp/release-notes.txt)
+
+          # Create PR
+          gh pr create \
+            --title "firmware: update Meshtastic v${PINNED} -> v${LATEST}" \
+            --label "firmware,upstream" \
+            --body "$(cat <<EOF
+          ## Meshtastic Firmware Update: v${PINNED} -> v${LATEST}
+
+          Automated version bump detected by firmware-watch workflow.
+
+          | | Version |
+          |---|---------|
+          | **Current (pinned)** | v${PINNED} (\`${PINNED_FULL}\`) |
+          | **Latest upstream** | v${LATEST} (\`${LATEST_FULL}\`) |
+
+          ### Release Notes (excerpt)
+
+          ${NOTES}
+
+          ### Links
+
+          - [Release page](https://github.com/meshtastic/firmware/releases/tag/${LATEST_TAG})
+          - [Full changelog](https://github.com/meshtastic/firmware/compare/v${PINNED_FULL}...${LATEST_TAG})
+
+          ### Review Checklist
+
+          - [ ] Review release notes for breaking changes
+          - [ ] Check for security advisories / CVEs
+          - [ ] Verify manifest.json version bump is correct
+          - [ ] Download and test on evaluation device
+          - [ ] Update SHA256 hashes after download
+
+          ### Post-Merge
+
+          On merge to \`main\`, the [build-firmware](.github/workflows/build-firmware.yml) workflow will automatically build custom LA-Mesh firmware for all devices.
+
+          \`\`\`bash
+          # Download new firmware after merge
+          just fetch-firmware
+
+          # Or test upstream before merge
+          just fetch-firmware --source upstream
+          \`\`\`
+          EOF
+          )"
+
+          echo "PR created for firmware update v${PINNED} -> v${LATEST}"
+
+      - name: Fallback to issue
+        if: steps.compare.outputs.update == 'true' && failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PINNED: ${{ steps.pinned.outputs.version }}
           LATEST: ${{ steps.latest.outputs.version }}
         run: |
-          echo "Update available: v$PINNED -> v$LATEST"
-
-          # Check if issue already exists
+          # If PR creation fails, fall back to creating an issue
           EXISTING=$(gh issue list --search "Firmware update: v$LATEST" --json number --jq '.[].number' || true)
           if [ -n "$EXISTING" ]; then
-            echo "Issue #$EXISTING already exists, skipping."
+            echo "Issue #$EXISTING already exists, skipping fallback."
             exit 0
           fi
 
-          # Create issue
           NOTES=$(cat /tmp/release-notes.txt)
           gh issue create \
-            --title "Firmware update: v$PINNED -> v$LATEST" \
+            --title "Firmware update: v${PINNED} -> v${LATEST} (auto-PR failed)" \
             --label "firmware,upstream" \
             --body "$(cat <<EOF
           ## Meshtastic Firmware Update Available
 
+          Automated PR creation failed. Manual version bump required.
+
           | | Version |
           |---|---------|
-          | **Current (pinned)** | v$PINNED |
-          | **Latest upstream** | v$LATEST |
+          | **Current (pinned)** | v${PINNED} |
+          | **Latest upstream** | v${LATEST} |
 
           ### Release Notes (excerpt)
 
-          $NOTES
+          ${NOTES}
 
           ### Links
 
-          - [Release page](https://github.com/meshtastic/firmware/releases/tag/v$LATEST)
-          - [Full changelog](https://github.com/meshtastic/firmware/compare/v$PINNED...v$LATEST)
+          - [Release page](https://github.com/meshtastic/firmware/releases/tag/v${LATEST})
+          - [Full changelog](https://github.com/meshtastic/firmware/compare/v${PINNED}...v${LATEST})
 
           ### Action Items
 
           - [ ] Review release notes for breaking changes
-          - [ ] Check for security advisories / CVEs
-          - [ ] Download and test on evaluation device
           - [ ] Update \`firmware/manifest.json\` version and SHA256 hashes
-          - [ ] Update \`firmware/meshtastic/update-checklist.md\` if needed
-          - [ ] Flash infrastructure nodes (routers, gateway)
-          - [ ] Flash client devices at next meetup
-
-          ### Commands
-
-          \`\`\`bash
-          # Download new firmware
-          just fetch-firmware --version $LATEST
-
-          # Update manifest hashes
-          just firmware-update-hashes
-
-          # Check a device
-          just provision station-g2 /dev/ttyUSB0
-          \`\`\`
+          - [ ] Merge to main to trigger CI firmware build
           EOF
           )"
-
-      - name: Up to date
-        if: steps.pinned.outputs.version == steps.latest.outputs.version
-        run: echo "Firmware is up to date (v${{ steps.pinned.outputs.version }})"

--- a/justfile
+++ b/justfile
@@ -68,7 +68,7 @@ dev-open:
 
 # Build docs site for production
 build:
-    cd site && DOCS_BASE_PATH=/LA-Mesh pnpm build
+    cd site && pnpm build
 
 # Preview production build
 preview: build

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,9 +3,11 @@
   "extends": [
     "config:recommended",
     ":semanticCommits",
-    "group:recommended"
+    "group:recommended",
+    ":automergePatch"
   ],
   "labels": ["dependencies"],
+  "schedule": ["before 6am on monday"],
   "packageRules": [
     {
       "groupName": "GitHub Actions",
@@ -17,6 +19,21 @@
       "groupName": "Nix flake inputs",
       "matchManagers": ["nix"],
       "schedule": ["before 6am on monday"]
+    },
+    {
+      "groupName": "SvelteKit ecosystem",
+      "matchPackagePatterns": ["^@sveltejs/", "^svelte", "^mdsvex"],
+      "schedule": ["before 6am on monday"]
+    },
+    {
+      "groupName": "Linting and formatting",
+      "matchPackagePatterns": ["prettier", "eslint", "markdownlint"],
+      "automerge": true,
+      "automergeType": "pr"
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security", "dependencies"]
+  }
 }

--- a/site/src/app.html
+++ b/site/src/app.html
@@ -7,6 +7,7 @@
 		<meta name="description" content="LA-Mesh - Community LoRa mesh network for Southern Maine" />
 		<meta property="og:title" content="LA-Mesh" />
 		<meta property="og:description" content="Community LoRa mesh network for Southern Maine" />
+		<meta property="og:url" content="https://la-mesh.me" />
 		<meta property="og:type" content="website" />
 		%sveltekit.head%
 	</head>

--- a/site/src/lib/components/Giscus.svelte
+++ b/site/src/lib/components/Giscus.svelte
@@ -1,0 +1,39 @@
+<script>
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+
+	onMount(() => {
+		const script = document.createElement('script');
+		script.src = 'https://giscus.app/client.js';
+		script.setAttribute('data-repo', 'Jesssullivan/LA-Mesh');
+		// TODO: Fill these after enabling GitHub Discussions on the repo
+		// Get values from https://giscus.app after setup
+		script.setAttribute('data-repo-id', '');
+		script.setAttribute('data-category', 'Docs Comments');
+		script.setAttribute('data-category-id', '');
+		script.setAttribute('data-mapping', 'pathname');
+		script.setAttribute('data-strict', '0');
+		script.setAttribute('data-reactions-enabled', '1');
+		script.setAttribute('data-emit-metadata', '0');
+		script.setAttribute('data-input-position', 'top');
+		script.setAttribute('data-theme', 'dark_dimmed');
+		script.setAttribute('data-lang', 'en');
+		script.setAttribute('crossorigin', 'anonymous');
+		script.async = true;
+
+		const container = document.getElementById('giscus-container');
+		if (container) container.appendChild(script);
+	});
+</script>
+
+<section class="giscus-wrapper">
+	<div id="giscus-container"></div>
+</section>
+
+<style>
+	.giscus-wrapper {
+		margin-top: 3rem;
+		padding-top: 2rem;
+		border-top: 1px solid rgba(255, 255, 255, 0.1);
+	}
+</style>

--- a/site/src/routes/guides/+layout.svelte
+++ b/site/src/routes/guides/+layout.svelte
@@ -1,0 +1,13 @@
+<script>
+	import Giscus from '$lib/components/Giscus.svelte';
+	import { page } from '$app/stores';
+
+	// Only show Giscus on individual guide pages, not the index
+	$: isGuidePage = $page.url.pathname !== '/guides' && $page.url.pathname !== '/guides/';
+</script>
+
+<slot />
+
+{#if isGuidePage}
+	<Giscus />
+{/if}

--- a/site/static/CNAME
+++ b/site/static/CNAME
@@ -1,0 +1,1 @@
+la-mesh.me


### PR DESCRIPTION
## Summary

- **Custom domain**: Switch GitHub Pages from `jesssullivan.github.io/LA-Mesh` to `la-mesh.me` (CNAME file, remove `DOCS_BASE_PATH`, update OG tags)
- **Giscus comments**: Add GitHub Discussions-backed comment widget to all `/guides/*` pages
- **Renovate enhancement**: Weekly schedule, SvelteKit/linting groups, auto-merge patches, vulnerability alerts
- **Firmware watch PRs**: Convert `firmware-watch.yml` from creating issues to creating version-bump PRs that update `firmware/manifest.json` (with issue fallback)

## Manual Steps Required

1. **DNS**: Configure A/CNAME records for `la-mesh.me` pointing to GitHub Pages IPs
2. **GitHub Settings**: Set custom domain to `la-mesh.me`, enable "Enforce HTTPS"
3. **GitHub Discussions**: Enable in repo Settings > Features
4. **Giscus App**: Install at https://github.com/apps/giscus
5. **Giscus IDs**: Get `data-repo-id` and `data-category-id` from https://giscus.app and update `site/src/lib/components/Giscus.svelte`

## Files Changed

| File | Change |
|------|--------|
| `site/static/CNAME` | New: `la-mesh.me` |
| `.github/workflows/deploy-pages.yml` | Remove `DOCS_BASE_PATH` env var |
| `justfile` | Remove `DOCS_BASE_PATH` from build recipe |
| `site/src/app.html` | Add `og:url` meta tag |
| `site/src/lib/components/Giscus.svelte` | New: Giscus comment component |
| `site/src/routes/guides/+layout.svelte` | New: guide layout with conditional Giscus |
| `renovate.json5` | Enhanced dependency management rules |
| `.github/workflows/firmware-watch.yml` | Create PRs instead of issues |

## Test Plan

- [x ] `pnpm --filter la-mesh-site build` succeeds without `DOCS_BASE_PATH`
- [ x] After DNS propagation: `curl -I https://la-mesh.me` returns 200
- [x ] Guide pages render Giscus widget at bottom (after Discussions enabled)
- [ x] Manual trigger of `firmware-watch.yml` creates a PR (not an issue)
- [ x] Renovate dashboard shows grouped dependency PRs on Monday schedule