### PR TITLE
Site overhaul: Skeleton UI v4 terminus dark theme

### DIFF
--- a/firmware/meshtastic/userPrefs.jsonc
+++ b/firmware/meshtastic/userPrefs.jsonc
@@ -27,5 +27,9 @@
 
     // --- Timezone (POSIX TZ format, required by v2.7.15+) ---
     // US Eastern: EST5EDT with standard DST rules
-    "USERPREFS_TZ_STRING": "EST5EDT,M3.2.0,M11.1.0"
+    "USERPREFS_TZ_STRING": "EST5EDT,M3.2.0,M11.1.0",
+
+    // --- Notification Ringtone (RTTTL format) ---
+    // Required by ExternalNotificationModule.cpp (no #ifdef guard)
+    "USERPREFS_RINGTONE_RTTTL": "24:d=32,o=5,b=565:f6,p,f6,p,f6,p,f6,p,p,p,p,p,f6,p,f6,p,f6,p,f6"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,15 +10,24 @@ importers:
 
   site:
     devDependencies:
+      '@skeletonlabs/skeleton':
+        specifier: ^4.12.0
+        version: 4.12.0(tailwindcss@4.1.18)
+      '@skeletonlabs/skeleton-svelte':
+        specifier: ^4.12.0
+        version: 4.12.0(svelte@5.50.2)
       '@sveltejs/adapter-static':
         specifier: ^3.0.0
-        version: 3.0.10(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.50.2)(vite@5.4.21))(svelte@5.50.2)(typescript@5.9.3)(vite@5.4.21))
+        version: 3.0.10(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2))(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)(typescript@5.9.3))
       '@sveltejs/kit':
         specifier: ^2.16.0
-        version: 2.50.2(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.50.2)(vite@5.4.21))(svelte@5.50.2)(typescript@5.9.3)(vite@5.4.21)
+        version: 2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2))(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)
+      '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.0.4(svelte@5.50.2)(vite@5.4.21)
+        version: 4.1.18(rolldown-vite@7.3.1(jiti@2.6.1))
       mdsvex:
         specifier: ^0.12.0
         version: 0.12.6(svelte@5.50.2)
@@ -28,158 +37,59 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.3.0
         version: 3.4.1(prettier@3.8.1)(svelte@5.50.2)
+      rehype-autolink-headings:
+        specifier: ^7.0.0
+        version: 7.1.0
+      rehype-external-links:
+        specifier: ^3.0.0
+        version: 3.0.0
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.1
+      shiki:
+        specifier: ^3.0.0
+        version: 3.22.0
       svelte:
         specifier: ^5.0.0
         version: 5.50.2
       svelte-check:
         specifier: ^4.0.0
         version: 4.3.6(picomatch@4.0.3)(svelte@5.50.2)(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.1.18
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vite:
-        specifier: ^5.0.0
-        version: 5.4.21
+        specifier: npm:rolldown-vite@latest
+        version: rolldown-vite@7.3.1(jiti@2.6.1)
 
 packages:
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
+  '@emnapi/core@1.8.1':
+    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
+  '@emnapi/runtime@1.8.1':
+    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
+  '@floating-ui/dom@1.7.5':
+    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
+  '@internationalized/date@3.10.1':
+    resolution: {integrity: sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -197,133 +107,132 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@oxc-project/runtime@0.101.0':
+    resolution: {integrity: sha512-t3qpfVZIqSiLQ5Kqt/MC4Ge/WCOGrrcagAdzTcDaggupjiGxUx4nJF2v6wUCXWSzWHn5Ns7XLv13fCJEwCOERQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.101.0':
+    resolution: {integrity: sha512-nuFhqlUzJX+gVIPPfuE6xurd4lST3mdcWOhyK/rZO0B9XWMKm79SuszIQEnSMmmDhq1DC8WWVYGVd+6F93o1gQ==}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
-    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.57.1':
-    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+  '@rolldown/binding-android-arm64@1.0.0-beta.53':
+    resolution: {integrity: sha512-Ok9V8o7o6YfSdTTYA/uHH30r3YtOxLD6G3wih/U9DO0ucBBFq8WPt/DslU53OgfteLRHITZny9N/qCUxMf9kjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.57.1':
-    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.53':
+    resolution: {integrity: sha512-yIsKqMz0CtRnVa6x3Pa+mzTihr4Ty+Z6HfPbZ7RVbk1Uxnco4+CUn7Qbm/5SBol1JD/7nvY8rphAgyAi7Lj6Vg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.57.1':
-    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.53':
+    resolution: {integrity: sha512-GTXe+mxsCGUnJOFMhfGWmefP7Q9TpYUseHvhAhr21nCTgdS8jPsvirb0tJwM3lN0/u/cg7bpFNa16fQrjKrCjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.57.1':
-    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.57.1':
-    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.53':
+    resolution: {integrity: sha512-9Tmp7bBvKqyDkMcL4e089pH3RsjD3SUungjmqWtyhNOxoQMh0fSmINTyYV8KXtE+JkxYMPWvnEt+/mfpVCkk8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
-    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.53':
+    resolution: {integrity: sha512-a1y5fiB0iovuzdbjUxa7+Zcvgv+mTmlGGC4XydVIsyl48eoxgaYkA3l9079hyTyhECsPq+mbr0gVQsFU11OJAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
-    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
-    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.53':
+    resolution: {integrity: sha512-bpIGX+ov9PhJYV+wHNXl9rzq4F0QvILiURn0y0oepbQx+7stmQsKA0DhPGwmhfvF856wq+gbM8L92SAa/CBcLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
-    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.53':
+    resolution: {integrity: sha512-bGe5EBB8FVjHBR1mOLOPEFg1Lp3//7geqWkU5NIhxe+yH0W8FVrQ6WRYOap4SUTKdklD/dC4qPLREkMMQ855FA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
-    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
-    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
-    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
-    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
-    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
-    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
-    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
+    resolution: {integrity: sha512-qL+63WKVQs1CMvFedlPt0U9PiEKJOAL/bsHMKUDS6Vp2Q+YAv/QLPu8rcvkfIMvQ0FPU2WL0aX4eWwF6e/GAnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.57.1':
-    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.53':
+    resolution: {integrity: sha512-VGl9JIGjoJh3H8Mb+7xnVqODajBmrdOOb9lxWXdcmxyI+zjB2sux69br0hZJDTyLJfvBoYm439zPACYbCjGRmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.57.1':
-    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.57.1':
-    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
+    resolution: {integrity: sha512-B4iIserJXuSnNzA5xBLFUIjTfhNy7d9sq4FUMQY3GhQWGVhS2RWWzzDnkSU6MUt7/aHUrep0CdQfXUJI9D3W7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
-    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.53':
+    resolution: {integrity: sha512-BUjAEgpABEJXilGq/BPh7jeU3WAJ5o15c1ZEgHaDWSz3LB881LQZnbNJHmUiM4d1JQWMYYyR1Y490IBHi2FPJg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.53':
+    resolution: {integrity: sha512-s27uU7tpCWSjHBnxyVXHt3rMrQdJq5MHNv3BzsewCIroIw3DJFjMH1dzCPPMUFxnh1r52Nf9IJ/eWp6LDoyGcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
-    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
-    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.53':
+    resolution: {integrity: sha512-cjWL/USPJ1g0en2htb4ssMjIycc36RvdQAx1WlXnS6DpULswiUTVXPDesTifSKYSyvx24E0YqQkEm0K/M2Z/AA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
-    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.0-beta.53':
+    resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
+
+  '@shikijs/core@3.22.0':
+    resolution: {integrity: sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==}
+
+  '@shikijs/engine-javascript@3.22.0':
+    resolution: {integrity: sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==}
+
+  '@shikijs/engine-oniguruma@3.22.0':
+    resolution: {integrity: sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==}
+
+  '@shikijs/langs@3.22.0':
+    resolution: {integrity: sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==}
+
+  '@shikijs/themes@3.22.0':
+    resolution: {integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==}
+
+  '@shikijs/types@3.22.0':
+    resolution: {integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@skeletonlabs/skeleton-common@4.12.0':
+    resolution: {integrity: sha512-nLobxtEfhUVtvET4asPbVaz9eDA9JFyskvF8j1WLcvK2mNxxku8JZE235Fz/QX5pR200KTXpjwYCp6Mfyb+0EA==}
+
+  '@skeletonlabs/skeleton-svelte@4.12.0':
+    resolution: {integrity: sha512-PkF+X6fNCDbXOnzbOzw0HzNzmK9vqZIdMS9StDvD4ixvrZgRa/vBTluCI9WMBa3TCtjMNkXhAxXBYI3LqLHq4A==}
+    peerDependencies:
+      svelte: ^5.29.0
+
+  '@skeletonlabs/skeleton@4.12.0':
+    resolution: {integrity: sha512-5Zch+aAarrWQaWEtjdb/jlaT5Q2H4Lt6pCl8utvrkKGGlXfAWd2yjzho75E1nxdbsS9F2q+5ipewlbrtmGYB8Q==}
+    peerDependencies:
+      tailwindcss: ^4.0.0
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -354,32 +263,290 @@ packages:
       typescript:
         optional: true
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1':
-    resolution: {integrity: sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==}
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^4.0.0-next.0||^4.0.0
-      svelte: ^5.0.0-next.96 || ^5.0.0
-      vite: ^5.0.0
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
 
-  '@sveltejs/vite-plugin-svelte@4.0.4':
-    resolution: {integrity: sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==}
+  '@sveltejs/vite-plugin-svelte@5.1.1':
+    resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22}
     peerDependencies:
-      svelte: ^5.0.0-next.96 || ^5.0.0
-      vite: ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
+  '@swc/helpers@0.5.18':
+    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
+
+  '@tailwindcss/node@4.1.18':
+    resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    resolution: {integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    resolution: {integrity: sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    resolution: {integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    resolution: {integrity: sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    resolution: {integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    resolution: {integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    resolution: {integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    resolution: {integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.18':
+    resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/vite@4.1.18':
+    resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@zag-js/accordion@1.32.0':
+    resolution: {integrity: sha512-sTn7xuaPvuG/YNO8aZIMBC0DMy+IacpxjduYUTdrjHrbvMKHuFdWuh9C7qg7AufM53bF1aWqVGltdIBXD9F8WA==}
+
+  '@zag-js/anatomy@1.32.0':
+    resolution: {integrity: sha512-99u8VBSt5wkP9ZluIV6lR06Pvyt0AQaTGnvhZkvSmbz5U5+1XwCU0Db7Q+dcQRpM7d0p1ViWFxNVHDuuwY25Fw==}
+
+  '@zag-js/aria-hidden@1.32.0':
+    resolution: {integrity: sha512-rgOSWjFMbeFwGPCdUWaSFbb4GM0Ovdr6sM0ilHmGQeXsrYkfg56R/o7I4/8P0kDIi/hDoE5TwBMUiGvKwWMLgA==}
+
+  '@zag-js/auto-resize@1.32.0':
+    resolution: {integrity: sha512-r9VnppK6rxsFhmfyaQSoHTEoD4yPQ4hmBDrXRoNTjpGeJoF9AKnzkY4YFFGZIuyWsFNLAMZJ3S6C3M2XZgzveA==}
+
+  '@zag-js/avatar@1.32.0':
+    resolution: {integrity: sha512-IdwVP/6EI51yUEW8CrCQp0dbzw2V2pcKUS8aayyB4+ihz0L9aWQDE6unUYuSc4xjxK1uGVGRdU67gEQCd6IXSg==}
+
+  '@zag-js/carousel@1.32.0':
+    resolution: {integrity: sha512-WKWrALPe+KWvsZY/ZIfJP3aU01qeghB16Mn8zd8AdL362pvQhKWhBLPSDk9OXh7OFcsiKm382gFHV5ko8CtBRw==}
+
+  '@zag-js/collapsible@1.32.0':
+    resolution: {integrity: sha512-kQwbPja0Nap1/ighmWCc5pemJG9Sx5Mw4zQ9p77O3znKbroq45AXSMr298Xx0zY44PEDhshKfLmeRT75jJRmpA==}
+
+  '@zag-js/collection@1.32.0':
+    resolution: {integrity: sha512-m4ViU0CdsTNiLjuIJknpPN8PPrsudfXC5GMAVykSBFnD6cnOWFKr7w4dM19Wp8VnlfsAsf4t86BPO+gsGm598w==}
+
+  '@zag-js/combobox@1.32.0':
+    resolution: {integrity: sha512-DITA9JhKcbX2IlowjqhZRK5a0Z0Y5ZRO0DUlueYFY5DUwiG1LIhV4AZolzpx24K95/L5V3c9+62DDbBeRS0Qsg==}
+
+  '@zag-js/core@1.32.0':
+    resolution: {integrity: sha512-aibBwyqw3saAzYBf2YHfuyOGt9kdNc4+ile3D1jbUsXiccLvGuFPP3+Ox7fULcILIiQhR0X6M+sTF17IyEMrYA==}
+
+  '@zag-js/date-picker@1.32.0':
+    resolution: {integrity: sha512-gfSPXKHE6IwbKXJrsyfi2pozsLdoiLCaxxX4hofa9nuenRDhgZjtkFeR4ZpmLomxKRjiDi2Hy4PLcfadMRxF2A==}
+    peerDependencies:
+      '@internationalized/date': '>=3.0.0'
+
+  '@zag-js/date-utils@1.32.0':
+    resolution: {integrity: sha512-TOhUURjMgaEpjDETwxcfuN9IdwjgtLWLBflaDCXZlipLQ7kuEDiT1G9tKKVr7ioZmapgd9b482sevH2H89Lxiw==}
+    peerDependencies:
+      '@internationalized/date': '>=3.0.0'
+
+  '@zag-js/dialog@1.32.0':
+    resolution: {integrity: sha512-aIrui9Wfxqags3jBsnAPBN7Af2U3icfbrHUXgAJ7cxsfsj58b7amM6Y42Ro7t1lBmpH86+3IxqfDkdBH1VQU7A==}
+
+  '@zag-js/dismissable@1.32.0':
+    resolution: {integrity: sha512-AUjajoaj2/3GfQvYJ5cdVwnov/dqAuS2N2dHRwxxSe/ktD4FbN/t0AcJ5Q2ojOuT6nBScEZQNd2vOrVgxLEiwQ==}
+
+  '@zag-js/dom-query@1.32.0':
+    resolution: {integrity: sha512-12XCCV1bchIFC7wjtYim5sEqUrAddzt0eysMTbBrCuK5r6TmLecwLtxUNKIRQ8adkCn0jqecUiuNyXojaArP3g==}
+
+  '@zag-js/file-upload@1.32.0':
+    resolution: {integrity: sha512-tuE3nOACmidiyu17GD13csInnmXS7xkWeJwGW0gFk20054uXA0ajF07NLCMpv6bToEgK+65/g3Vn0Mkw92X7lQ==}
+
+  '@zag-js/file-utils@1.32.0':
+    resolution: {integrity: sha512-bZ43xFGt6zn7zKKvAi/WNG7uhvOPRwR8xv/yrHk9W3IPqEj3k3zYkZkfQQbwfBKwWWcQe48WtzV+hwSDsatvOg==}
+
+  '@zag-js/floating-panel@1.32.0':
+    resolution: {integrity: sha512-qBZHA1Y4v8f9so8LcHVJXwfe+3qJ7M+6mRpl3llQO+InlPtXAd1jiBUa4u9v5PHj74Rmc0cWo+HJ2dPobynDCw==}
+
+  '@zag-js/focus-trap@1.32.0':
+    resolution: {integrity: sha512-irzYMaz1ycAnHOGLr4r6+3MwhfKnA67N9jPft9ejnE2QoTp40W+xp07K2KQNf6xN7Boe6xGlw8SwLBnGZw2eCQ==}
+
+  '@zag-js/focus-visible@1.32.0':
+    resolution: {integrity: sha512-/Gwu6Yt/c8tgpx32vkOxj2AIdmNdJv0WFHNBTl3xu60FR65oFfdpJsZR6MEbyL0F+srTYxuLZMdIoW5bN6nkQA==}
+
+  '@zag-js/i18n-utils@1.32.0':
+    resolution: {integrity: sha512-OMJTVMKjESWCAndYAi5kn+aYmVsU2pgJPWfH2nDS/wvGI4Z7WpJbbGZixbP7k6BSqewXS71xZRu98CNmL0IWwA==}
+
+  '@zag-js/interact-outside@1.32.0':
+    resolution: {integrity: sha512-OwQgBxijmv9ZXFu6WzhLRULJh0FoixuP6DJV9B2CGBKJZz4hbQAqVrW9PFaPiBuWOILZpZ/iI6ZDjkGSKZ0WHw==}
+
+  '@zag-js/listbox@1.32.0':
+    resolution: {integrity: sha512-7zENHml+igdm8xRiPSKTzEqUbRhSiusMv4JWSLamHswF+jN9ZG7yany1MEwiPrqizY9O3DbO/JYuZXliPsBACQ==}
+
+  '@zag-js/live-region@1.32.0':
+    resolution: {integrity: sha512-TN3fz8bk1k3ovGQJm7Lsr9xAaU+TwyPLhbBQzuApwz1aUzY4PFNdSdK56P7jnFlw6vrFq8/yOwUoDlTRzTGeRA==}
+
+  '@zag-js/menu@1.32.0':
+    resolution: {integrity: sha512-vMOPYg2a6dnTu8+E2wUptYkkdGyViUvf6je4+WEc5w0AGU1sGaZE+jckPK9f8vPUhL2I2TqwiI5dg85L+JZ1uw==}
+
+  '@zag-js/pagination@1.32.0':
+    resolution: {integrity: sha512-cfPaO9GyDSB1luaNEkh+RUYQzv1qZqP17Hq3AlJZQ5LQWc97U0ZyiptMm6oXApDKREoUhNcRNdpG9Mo5vz8Rbg==}
+
+  '@zag-js/popover@1.32.0':
+    resolution: {integrity: sha512-GTUQTWtMLyIXxHeV9dQy+xmIQVZ0KAION0XX/211ncrzWZ5guQXa2LECEH252uIEehRwRaFY08cZsacTqTOKsg==}
+
+  '@zag-js/popper@1.32.0':
+    resolution: {integrity: sha512-nTSdbgZKIEERNEpNhMlbATRiKhMrxo0t2206MbVhrM52TuraIc+nRmJNwWKoagalXs62/TlSpFvXmcpVyfWTMQ==}
+
+  '@zag-js/progress@1.32.0':
+    resolution: {integrity: sha512-BvxmOUqUFh8W0g/6kRMr991aGgoOq1nWos2gOrni6UKDz2KWyIfiMl4mhobsal8a8u3f/58zLNHp21VKd578NQ==}
+
+  '@zag-js/radio-group@1.32.0':
+    resolution: {integrity: sha512-OoCVyh7JK1WIbmoWtjOr56joi3J9RyL/fHMQlX6Nk1a4wCB1Bb0aZ6TgSDqMBrcPG7ufIqdEagSU0o5Uq9GD6Q==}
+
+  '@zag-js/rating-group@1.32.0':
+    resolution: {integrity: sha512-lEXxuhxHMHCSgMEilLKJjEF4vTgnCHaNIsZG9XRTL8BTIjbusTmvB6i3s2edLEdy0IFNK1HJ6JIXMT1G4r6fPg==}
+
+  '@zag-js/rect-utils@1.32.0':
+    resolution: {integrity: sha512-waBJL57PA90mYRMCDF7WNa3ZEfNhnWPu6lGqNB1Lh/1GMUzIto1X/Lw1oJoGig8Ui9Af9pgRG4QPyKSRULFgKQ==}
+
+  '@zag-js/remove-scroll@1.32.0':
+    resolution: {integrity: sha512-gWx8z/8ayNo624ibET4cNWbdVLc8A0Vyy9L9t67KT/slrBjcOA/zp9JL3Ngw/TZKgtR+wDh7P8ZoNAe0euaLSQ==}
+
+  '@zag-js/scroll-snap@1.32.0':
+    resolution: {integrity: sha512-N77nO4dhDyLYeemrUBEGuJEl7u357WjMozEkErLzpg4vSTIOrzHPh1oqVzykcQa/eVq9qyHGz4/txqgkEy+fbg==}
+
+  '@zag-js/slider@1.32.0':
+    resolution: {integrity: sha512-sbxQWp+/YxSvMDNkl5QDU7JyN6AGszASBZ1fT41Ctup17CQXnTwRK6CaAr00fgd4d21JlWd7T74/M393XgA6iQ==}
+
+  '@zag-js/steps@1.32.0':
+    resolution: {integrity: sha512-b0tA20GG5Kb+JDUHFPFT4QEQiDMsotWlIFXphntkzXFNqXOc/stPfllT78YoDAGx5hnvE20fSHooXze9A5Ad5Q==}
+
+  '@zag-js/store@1.32.0':
+    resolution: {integrity: sha512-m9jvTKJB/lTC2I8NpDf+yo2XVN+ogxjiVbGsooAFTpyUAiXZY50nVc9cFcswnwFMo/GzXMk81oalyz9u65jqRQ==}
+
+  '@zag-js/svelte@1.32.0':
+    resolution: {integrity: sha512-Coth0r/owg+1L9tapDDAEKzYf2dezaugvDAfRMvl/rrsUIYtsm6z6ceKcMq0NFzVPB5jsYTW/tK9RW05Xr0Zsg==}
+    peerDependencies:
+      svelte: '>=5'
+
+  '@zag-js/switch@1.32.0':
+    resolution: {integrity: sha512-im6kDxjT/HT7T7+4/2VHpJm744SxN9SK9fNJMU48LYmO55Qi3Ftz89Gp19P2cv9KxFgR9o0gGZH4adELULtJTQ==}
+
+  '@zag-js/tabs@1.32.0':
+    resolution: {integrity: sha512-ZgRHQmE+np/EPEUtSsCrYJLWFdW9JXtXE6vb1uJfR4K4yUGxGMRdBuKeeRSTMUtSLqXyo9KwDYQtAQa/RdnOHg==}
+
+  '@zag-js/tags-input@1.32.0':
+    resolution: {integrity: sha512-Aj0no7TpJGU5NkcXDYKuoKuEZhePkb8baPsLx1K76QOYpwDxujlOy2BemtGisxmWHidjQROYJIr7ks31iNcXmA==}
+
+  '@zag-js/toast@1.32.0':
+    resolution: {integrity: sha512-f5APsASyGmhKlpQ/Wxc4bp9hAUVuXqV6FoHnu7ugfIuYllIaSz/RHgsb4yZvLjweNE24cw4B9Rjj9njOZGPe6Q==}
+
+  '@zag-js/toggle-group@1.32.0':
+    resolution: {integrity: sha512-1opPWPMgDqk/NnD42F/bh1nOBcr6N+pYG53D/agifDxuhh+kiAFJ4QubLK+1758J55fIQWclToAbKZO7U8UCLQ==}
+
+  '@zag-js/tooltip@1.32.0':
+    resolution: {integrity: sha512-V3GJXCgSTiijqZTqJnRQ5HClL8GUtGhfczcB9fV+T2+mbwZXahfNQ0Fjrfi2Itb4WLCTovOi9iIAlfl3S1V/pQ==}
+
+  '@zag-js/tree-view@1.32.0':
+    resolution: {integrity: sha512-brMHrwmDDfuPFcsciHLwb941hBy/Zm9hug0325HNgNLKVCjiJ2Gewnay373IQhxDJHeuF+9htJlq3bhMlHeLTw==}
+
+  '@zag-js/types@1.32.0':
+    resolution: {integrity: sha512-9UV5mFnTgJRyFCCH9g/TIqtxxfw6FUphpe7E0AHK9+WSq3PRvflMeaRT/O6HgdWo0Rc+JN9vVwkFYyGD81uAbw==}
+
+  '@zag-js/utils@1.32.0':
+    resolution: {integrity: sha512-IRe1yFbMXBp8Q1Xp916Lq9P91s65K5KRNFZIv2EdQHRynLaT+QrPp5hmzkWoXJn8oOYd6PZeNb7K6v7vk8+k1g==}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -394,6 +561,21 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -402,9 +584,15 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -415,23 +603,43 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   devalue@5.6.2:
     resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
 
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  enhanced-resolve@5.19.0:
+    resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
+    engines: {node: '>=10.13.0'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-    hasBin: true
 
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   esrap@2.2.3:
     resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -447,23 +655,255 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  lightningcss-android-arm64@1.30.2:
+    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.30.2:
+    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.2:
+    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.2:
+    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.2:
+    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.2:
+    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdsvex@0.12.6:
     resolution: {integrity: sha512-pupx2gzWh3hDtm/iDW4WuCpljmyHbHi34r7ktOqpPGvyiM4MyfNgdJ3qMizXdgCErmvYC9Nn/qyjePy+4ss9Wg==}
     peerDependencies:
       svelte: ^3.56.0 || ^4.0.0 || ^5.0.0-next.120
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -480,6 +920,12 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+
+  oniguruma-to-es@4.3.4:
+    resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -510,13 +956,86 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  proxy-compare@3.0.1:
+    resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
-  rollup@4.57.1:
-    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rehype-autolink-headings@7.1.0:
+    resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
+
+  rehype-external-links@3.0.0:
+    resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  rolldown-vite@7.3.1:
+    resolution: {integrity: sha512-LYzdNAjRHhF2yA4JUQm/QyARyi216N2rpJ0lJZb8E9FU2y5v6Vk+xq/U4XBOxMefpWixT5H3TslmAHm1rqIq2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  rolldown@1.0.0-beta.53:
+    resolution: {integrity: sha512-Qd9c2p0XKZdgT5AYd+KgAMggJ8ZmCs3JnS9PTMWkyUfteKlfmKtxJbWTHkVakxwXs1Ub7jrRYVeFeF7N0sQxyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   sade@1.8.1:
@@ -526,6 +1045,9 @@ packages:
   set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
 
+  shiki@3.22.0:
+    resolution: {integrity: sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -533,6 +1055,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   svelte-check@4.3.6:
     resolution: {integrity: sha512-uBkz96ElE3G4pt9E1Tw0xvBfIUQkeH794kDQZdAUk795UVMr+NJZpuFSS62vcmO/DuSalK83LyOwhgWq8YGU1Q==}
@@ -546,60 +1074,73 @@ packages:
     resolution: {integrity: sha512-WCxzm3BBf+Ase6RwiDPR4G36cM4Kb0NuhmLK6x44I+D6reaxizDDg8kBkk4jT/19+Rgmc44eZkOvMO6daoSFIw==}
     engines: {node: '>=18'}
 
+  tailwindcss@4.1.18:
+    resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
+
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
 
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
   unist-util-visit-parents@3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
   unist-util-visit@2.0.3:
     resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
 
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
 
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vitefu@1.1.1:
     resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
@@ -612,76 +1153,41 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
 
-  '@esbuild/aix-ppc64@0.21.5':
+  '@emnapi/core@1.8.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  '@emnapi/runtime@1.8.1':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
-    optional: true
+  '@floating-ui/core@1.7.4':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
 
-  '@esbuild/darwin-arm64@0.21.5':
-    optional: true
+  '@floating-ui/dom@1.7.5':
+    dependencies:
+      '@floating-ui/core': 1.7.4
+      '@floating-ui/utils': 0.2.10
 
-  '@esbuild/darwin-x64@0.21.5':
-    optional: true
+  '@floating-ui/utils@0.2.10': {}
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-arm@0.21.5':
-    optional: true
-
-  '@esbuild/linux-ia32@0.21.5':
-    optional: true
-
-  '@esbuild/linux-loong64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.21.5':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.21.5':
-    optional: true
-
-  '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
-  '@esbuild/linux-x64@0.21.5':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.5':
-    optional: true
-
-  '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.5':
-    optional: true
-
-  '@esbuild/win32-ia32@0.21.5':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.5':
-    optional: true
+  '@internationalized/date@3.10.1':
+    dependencies:
+      '@swc/helpers': 0.5.18
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -702,82 +1208,133 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.8.1
+      '@emnapi/runtime': 1.8.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/runtime@0.101.0': {}
+
+  '@oxc-project/types@0.101.0': {}
+
   '@polka/url@1.0.0-next.29': {}
 
-  '@rollup/rollup-android-arm-eabi@4.57.1':
+  '@rolldown/binding-android-arm64@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.57.1':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.57.1':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.57.1':
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.57.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.57.1':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.57.1':
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.53':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.57.1':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.53':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.57.1':
-    optional: true
+  '@rolldown/pluginutils@1.0.0-beta.53': {}
 
-  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
-    optional: true
+  '@shikijs/core@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
 
-  '@rollup/rollup-linux-riscv64-musl@4.57.1':
-    optional: true
+  '@shikijs/engine-javascript@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.4
 
-  '@rollup/rollup-linux-s390x-gnu@4.57.1':
-    optional: true
+  '@shikijs/engine-oniguruma@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
 
-  '@rollup/rollup-linux-x64-gnu@4.57.1':
-    optional: true
+  '@shikijs/langs@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
 
-  '@rollup/rollup-linux-x64-musl@4.57.1':
-    optional: true
+  '@shikijs/themes@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
 
-  '@rollup/rollup-openbsd-x64@4.57.1':
-    optional: true
+  '@shikijs/types@3.22.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
-  '@rollup/rollup-openharmony-arm64@4.57.1':
-    optional: true
+  '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@rollup/rollup-win32-arm64-msvc@4.57.1':
-    optional: true
+  '@skeletonlabs/skeleton-common@4.12.0': {}
 
-  '@rollup/rollup-win32-ia32-msvc@4.57.1':
-    optional: true
+  '@skeletonlabs/skeleton-svelte@4.12.0(svelte@5.50.2)':
+    dependencies:
+      '@internationalized/date': 3.10.1
+      '@skeletonlabs/skeleton-common': 4.12.0
+      '@zag-js/accordion': 1.32.0
+      '@zag-js/avatar': 1.32.0
+      '@zag-js/carousel': 1.32.0
+      '@zag-js/collapsible': 1.32.0
+      '@zag-js/collection': 1.32.0
+      '@zag-js/combobox': 1.32.0
+      '@zag-js/date-picker': 1.32.0(@internationalized/date@3.10.1)
+      '@zag-js/dialog': 1.32.0
+      '@zag-js/file-upload': 1.32.0
+      '@zag-js/floating-panel': 1.32.0
+      '@zag-js/listbox': 1.32.0
+      '@zag-js/menu': 1.32.0
+      '@zag-js/pagination': 1.32.0
+      '@zag-js/popover': 1.32.0
+      '@zag-js/progress': 1.32.0
+      '@zag-js/radio-group': 1.32.0
+      '@zag-js/rating-group': 1.32.0
+      '@zag-js/slider': 1.32.0
+      '@zag-js/steps': 1.32.0
+      '@zag-js/svelte': 1.32.0(svelte@5.50.2)
+      '@zag-js/switch': 1.32.0
+      '@zag-js/tabs': 1.32.0
+      '@zag-js/tags-input': 1.32.0
+      '@zag-js/toast': 1.32.0
+      '@zag-js/toggle-group': 1.32.0
+      '@zag-js/tooltip': 1.32.0
+      '@zag-js/tree-view': 1.32.0
+      svelte: 5.50.2
 
-  '@rollup/rollup-win32-x64-gnu@4.57.1':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.57.1':
-    optional: true
+  '@skeletonlabs/skeleton@4.12.0(tailwindcss@4.1.18)':
+    dependencies:
+      tailwindcss: 4.1.18
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -785,15 +1342,15 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.50.2)(vite@5.4.21))(svelte@5.50.2)(typescript@5.9.3)(vite@5.4.21))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2))(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)(typescript@5.9.3))':
     dependencies:
-      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.50.2)(vite@5.4.21))(svelte@5.50.2)(typescript@5.9.3)(vite@5.4.21)
+      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2))(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)(typescript@5.9.3)
 
-  '@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.50.2)(vite@5.4.21))(svelte@5.50.2)(typescript@5.9.3)(vite@5.4.21)':
+  '@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2))(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)(typescript@5.9.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.50.2)(vite@5.4.21)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -806,41 +1363,459 @@ snapshots:
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
       svelte: 5.50.2
-      vite: 5.4.21
+      vite: rolldown-vite@7.3.1(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.50.2)(vite@5.4.21))(svelte@5.50.2)(vite@5.4.21)':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2))(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.50.2)(vite@5.4.21)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)
       debug: 4.4.3
       svelte: 5.50.2
-      vite: 5.4.21
+      vite: rolldown-vite@7.3.1(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.50.2)(vite@5.4.21)':
+  '@sveltejs/vite-plugin-svelte@5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.50.2)(vite@5.4.21))(svelte@5.50.2)(vite@5.4.21)
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2))(rolldown-vite@7.3.1(jiti@2.6.1))(svelte@5.50.2)
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.50.2
-      vite: 5.4.21
-      vitefu: 1.1.1(vite@5.4.21)
+      vite: rolldown-vite@7.3.1(jiti@2.6.1)
+      vitefu: 1.1.1(rolldown-vite@7.3.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
+  '@swc/helpers@0.5.18':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tailwindcss/node@4.1.18':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.19.0
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.18
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.18':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-x64': 4.1.18
+      '@tailwindcss/oxide-freebsd-x64': 4.1.18
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.18
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.18
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.18
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
+
+  '@tailwindcss/vite@4.1.18(rolldown-vite@7.3.1(jiti@2.6.1))':
+    dependencies:
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      tailwindcss: 4.1.18
+      vite: rolldown-vite@7.3.1(jiti@2.6.1)
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/cookie@0.6.0': {}
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 2.0.11
 
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 2.0.11
 
+  '@types/ms@2.1.0': {}
+
   '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@zag-js/accordion@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/anatomy@1.32.0': {}
+
+  '@zag-js/aria-hidden@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/auto-resize@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/avatar@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/carousel@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/scroll-snap': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/collapsible@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/collection@1.32.0':
+    dependencies:
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/combobox@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/aria-hidden': 1.32.0
+      '@zag-js/collection': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/core@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/date-picker@1.32.0(@internationalized/date@3.10.1)':
+    dependencies:
+      '@internationalized/date': 3.10.1
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/date-utils': 1.32.0(@internationalized/date@3.10.1)
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/live-region': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/date-utils@1.32.0(@internationalized/date@3.10.1)':
+    dependencies:
+      '@internationalized/date': 3.10.1
+
+  '@zag-js/dialog@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/aria-hidden': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-trap': 1.32.0
+      '@zag-js/remove-scroll': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/dismissable@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/interact-outside': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/dom-query@1.32.0':
+    dependencies:
+      '@zag-js/types': 1.32.0
+
+  '@zag-js/file-upload@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/file-utils': 1.32.0
+      '@zag-js/i18n-utils': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/file-utils@1.32.0':
+    dependencies:
+      '@zag-js/i18n-utils': 1.32.0
+
+  '@zag-js/floating-panel@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/rect-utils': 1.32.0
+      '@zag-js/store': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/focus-trap@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/focus-visible@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/i18n-utils@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/interact-outside@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/listbox@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/collection': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-visible': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/live-region@1.32.0': {}
+
+  '@zag-js/menu@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/rect-utils': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/pagination@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/popover@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/aria-hidden': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-trap': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/remove-scroll': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/popper@1.32.0':
+    dependencies:
+      '@floating-ui/dom': 1.7.5
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/progress@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/radio-group@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-visible': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/rating-group@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/rect-utils@1.32.0': {}
+
+  '@zag-js/remove-scroll@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/scroll-snap@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/slider@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/steps@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/store@1.32.0':
+    dependencies:
+      proxy-compare: 3.0.1
+
+  '@zag-js/svelte@1.32.0(svelte@5.50.2)':
+    dependencies:
+      '@zag-js/core': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+      svelte: 5.50.2
+
+  '@zag-js/switch@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-visible': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/tabs@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/tags-input@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/auto-resize': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/interact-outside': 1.32.0
+      '@zag-js/live-region': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/toast@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/toggle-group@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/tooltip@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-visible': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/tree-view@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/collection': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/types@1.32.0':
+    dependencies:
+      csstype: 3.2.3
+
+  '@zag-js/utils@1.32.0': {}
 
   acorn@8.15.0: {}
 
@@ -848,53 +1823,62 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
+  ccount@2.0.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
 
   clsx@2.1.1: {}
 
+  comma-separated-tokens@2.0.3: {}
+
   cookie@0.6.0: {}
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deepmerge@4.3.1: {}
+
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
 
   devalue@5.6.2: {}
 
-  esbuild@0.21.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  enhanced-resolve@5.19.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
+
+  escape-string-regexp@5.0.0: {}
 
   esm-env@1.2.2: {}
 
   esrap@2.2.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  extend@3.0.2: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -903,17 +1887,226 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  github-slugger@2.0.0: {}
+
+  graceful-fs@4.2.11: {}
+
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  html-void-elements@3.0.0: {}
+
+  is-absolute-url@4.0.1: {}
+
+  is-plain-obj@4.1.0: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  jiti@2.6.1: {}
+
   kleur@4.1.5: {}
 
+  lightningcss-android-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.2:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss@1.30.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.30.2
+      lightningcss-darwin-arm64: 1.30.2
+      lightningcss-darwin-x64: 1.30.2
+      lightningcss-freebsd-x64: 1.30.2
+      lightningcss-linux-arm-gnueabihf: 1.30.2
+      lightningcss-linux-arm64-gnu: 1.30.2
+      lightningcss-linux-arm64-musl: 1.30.2
+      lightningcss-linux-x64-gnu: 1.30.2
+      lightningcss-linux-x64-musl: 1.30.2
+      lightningcss-win32-arm64-msvc: 1.30.2
+      lightningcss-win32-x64-msvc: 1.30.2
+
   locate-character@3.0.0: {}
+
+  longest-streak@3.1.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdsvex@0.12.6(svelte@5.50.2):
     dependencies:
@@ -925,6 +2118,197 @@ snapshots:
       unist-util-visit: 2.0.3
       vfile-message: 2.0.4
 
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -933,10 +2317,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  oniguruma-parser@0.12.1: {}
+
+  oniguruma-to-es@4.3.4:
+    dependencies:
+      oniguruma-parser: 0.12.1
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3:
-    optional: true
+  picomatch@4.0.3: {}
 
   postcss@8.5.6:
     dependencies:
@@ -955,44 +2346,122 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  property-information@7.1.0: {}
+
+  proxy-compare@3.0.1: {}
+
   readdirp@4.1.2: {}
 
-  rollup@4.57.1:
+  regex-recursion@6.0.2:
     dependencies:
-      '@types/estree': 1.0.8
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  rehype-autolink-headings@7.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-is-element: 3.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  rehype-external-links@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-is-element: 3.0.0
+      is-absolute-url: 4.0.1
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 5.1.0
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  rolldown-vite@7.3.1(jiti@2.6.1):
+    dependencies:
+      '@oxc-project/runtime': 0.101.0
+      fdir: 6.5.0(picomatch@4.0.3)
+      lightningcss: 1.30.2
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rolldown: 1.0.0-beta.53
+      tinyglobby: 0.2.15
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.57.1
-      '@rollup/rollup-android-arm64': 4.57.1
-      '@rollup/rollup-darwin-arm64': 4.57.1
-      '@rollup/rollup-darwin-x64': 4.57.1
-      '@rollup/rollup-freebsd-arm64': 4.57.1
-      '@rollup/rollup-freebsd-x64': 4.57.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
-      '@rollup/rollup-linux-arm64-gnu': 4.57.1
-      '@rollup/rollup-linux-arm64-musl': 4.57.1
-      '@rollup/rollup-linux-loong64-gnu': 4.57.1
-      '@rollup/rollup-linux-loong64-musl': 4.57.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
-      '@rollup/rollup-linux-ppc64-musl': 4.57.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
-      '@rollup/rollup-linux-riscv64-musl': 4.57.1
-      '@rollup/rollup-linux-s390x-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-gnu': 4.57.1
-      '@rollup/rollup-linux-x64-musl': 4.57.1
-      '@rollup/rollup-openbsd-x64': 4.57.1
-      '@rollup/rollup-openharmony-arm64': 4.57.1
-      '@rollup/rollup-win32-arm64-msvc': 4.57.1
-      '@rollup/rollup-win32-ia32-msvc': 4.57.1
-      '@rollup/rollup-win32-x64-gnu': 4.57.1
-      '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
+      jiti: 2.6.1
+
+  rolldown@1.0.0-beta.53:
+    dependencies:
+      '@oxc-project/types': 0.101.0
+      '@rolldown/pluginutils': 1.0.0-beta.53
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.53
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.53
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.53
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.53
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.53
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.53
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.53
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.53
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.53
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.53
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.53
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.53
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.53
 
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
 
   set-cookie-parser@3.0.1: {}
+
+  shiki@3.22.0:
+    dependencies:
+      '@shikijs/core': 3.22.0
+      '@shikijs/engine-javascript': 3.22.0
+      '@shikijs/engine-oniguruma': 3.22.0
+      '@shikijs/langs': 3.22.0
+      '@shikijs/themes': 3.22.0
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   sirv@3.0.2:
     dependencies:
@@ -1001,6 +2470,13 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   svelte-check@4.3.6(picomatch@4.0.3)(svelte@5.50.2)(typescript@5.9.3):
     dependencies:
@@ -1032,20 +2508,62 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
+  tailwindcss@4.1.18: {}
+
+  tapable@2.3.0: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
   totalist@3.0.1: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  tslib@2.8.1: {}
 
   typescript@5.9.3: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unist-util-is@4.1.0: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
 
   unist-util-stringify-position@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
 
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
   unist-util-visit-parents@3.1.1:
     dependencies:
       '@types/unist': 2.0.11
       unist-util-is: 4.1.0
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
 
   unist-util-visit@2.0.3:
     dependencies:
@@ -1053,21 +2571,31 @@ snapshots:
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
 
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   vfile-message@2.0.4:
     dependencies:
       '@types/unist': 2.0.11
       unist-util-stringify-position: 2.0.3
 
-  vite@5.4.21:
+  vfile-message@4.0.3:
     dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.57.1
-    optionalDependencies:
-      fsevents: 2.3.3
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
 
-  vitefu@1.1.1(vite@5.4.21):
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vitefu@1.1.1(rolldown-vite@7.3.1(jiti@2.6.1)):
     optionalDependencies:
-      vite: 5.4.21
+      vite: rolldown-vite@7.3.1(jiti@2.6.1)
 
   zimmerframe@1.1.4: {}
+
+  zwitch@2.0.4: {}

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "la-mesh-site",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -12,16 +12,25 @@
     "lint": "prettier --check . && eslint ."
   },
   "devDependencies": {
+    "@skeletonlabs/skeleton": "^4.12.0",
+    "@skeletonlabs/skeleton-svelte": "^4.12.0",
     "@sveltejs/adapter-static": "^3.0.0",
     "@sveltejs/kit": "^2.16.0",
-    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@tailwindcss/vite": "^4.0.0",
     "mdsvex": "^0.12.0",
     "prettier": "^3.4.0",
     "prettier-plugin-svelte": "^3.3.0",
+    "rehype-autolink-headings": "^7.0.0",
+    "rehype-external-links": "^3.0.0",
+    "rehype-slug": "^6.0.0",
+    "remark-gfm": "^4.0.0",
+    "shiki": "^3.0.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
+    "tailwindcss": "^4.0.0",
     "typescript": "^5.0.0",
-    "vite": "^5.0.0"
+    "vite": "npm:rolldown-vite@latest"
   },
   "engines": {
     "node": ">=20"

--- a/site/src/app.css
+++ b/site/src/app.css
@@ -1,0 +1,84 @@
+@import 'tailwindcss';
+@import '@skeletonlabs/skeleton';
+@import '@skeletonlabs/skeleton-svelte';
+@import '@skeletonlabs/skeleton/themes/terminus';
+
+/* Enable Selector Strategy for dark mode toggle */
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* Required for light-dark() function to work with color pairings */
+@layer base {
+	html {
+		color-scheme: light;
+	}
+	html.dark {
+		color-scheme: dark;
+	}
+}
+
+/* Shiki code block styling */
+pre.shiki {
+	padding: 1rem 1.25rem;
+	border-radius: 0.5rem;
+	overflow-x: auto;
+	font-size: 0.875rem;
+	line-height: 1.7;
+	border: 1px solid light-dark(var(--color-surface-300), var(--color-surface-700));
+}
+
+/* MDsveX content prose defaults */
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
+	color: light-dark(var(--color-surface-950), var(--color-surface-50));
+}
+
+.prose a {
+	color: light-dark(var(--color-primary-700), var(--color-primary-400));
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.prose a:hover {
+	color: light-dark(var(--color-primary-500), var(--color-primary-300));
+}
+
+.prose code:not(pre code) {
+	font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+	color: light-dark(var(--color-primary-700), var(--color-primary-400));
+	background: light-dark(var(--color-surface-200), var(--color-surface-800));
+	padding: 0.125rem 0.375rem;
+	border-radius: 0.25rem;
+	font-size: 0.875em;
+}
+
+.prose table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.prose th {
+	background: light-dark(var(--color-surface-200), var(--color-surface-800));
+	color: light-dark(var(--color-surface-700), var(--color-surface-300));
+	padding: 0.75rem 1rem;
+	text-align: left;
+	font-size: 0.85rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.prose td {
+	color: light-dark(var(--color-surface-900), var(--color-surface-200));
+	padding: 0.75rem 1rem;
+	border-bottom: 1px solid light-dark(var(--color-surface-200), var(--color-surface-700));
+}
+
+.prose blockquote {
+	border-left: 3px solid light-dark(var(--color-primary-500), var(--color-primary-500));
+	padding: 0.75rem 1rem;
+	margin: 1rem 0;
+	background: light-dark(var(--color-surface-100), var(--color-surface-800));
+	border-radius: 0 0.25rem 0.25rem 0;
+}

--- a/site/src/app.html
+++ b/site/src/app.html
@@ -1,9 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="terminus" class="dark">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#15171f" />
 		<meta name="description" content="LA-Mesh - Community LoRa mesh network for Southern Maine" />
 		<meta property="og:title" content="LA-Mesh" />
 		<meta property="og:description" content="Community LoRa mesh network for Southern Maine" />

--- a/site/src/lib/components/Giscus.svelte
+++ b/site/src/lib/components/Giscus.svelte
@@ -1,6 +1,5 @@
 <script>
 	import { onMount } from 'svelte';
-	import { page } from '$app/stores';
 
 	onMount(() => {
 		const script = document.createElement('script');
@@ -14,7 +13,7 @@
 		script.setAttribute('data-reactions-enabled', '1');
 		script.setAttribute('data-emit-metadata', '0');
 		script.setAttribute('data-input-position', 'top');
-		script.setAttribute('data-theme', 'dark_dimmed');
+		script.setAttribute('data-theme', 'noborder_dark');
 		script.setAttribute('data-lang', 'en');
 		script.setAttribute('crossorigin', 'anonymous');
 		script.async = true;
@@ -24,14 +23,6 @@
 	});
 </script>
 
-<section class="giscus-wrapper">
+<section class="mt-12 pt-8 border-t border-surface-700">
 	<div id="giscus-container"></div>
 </section>
-
-<style>
-	.giscus-wrapper {
-		margin-top: 3rem;
-		padding-top: 2rem;
-		border-top: 1px solid rgba(255, 255, 255, 0.1);
-	}
-</style>

--- a/site/src/lib/components/StatusBadge.svelte
+++ b/site/src/lib/components/StatusBadge.svelte
@@ -1,0 +1,22 @@
+<script>
+	/** @type {{ status: 'working' | 'planned' | 'experimental' }} */
+	let { status } = $props();
+
+	/** @type {Record<string, string>} */
+	const styles = {
+		working: 'bg-green-500/20 text-green-400',
+		planned: 'bg-yellow-500/20 text-yellow-400',
+		experimental: 'bg-orange-500/20 text-orange-400'
+	};
+
+	/** @type {Record<string, string>} */
+	const labels = {
+		working: 'Working',
+		planned: 'Planned',
+		experimental: 'Experimental'
+	};
+</script>
+
+<span class="px-2 py-0.5 rounded text-xs font-medium {styles[status]}">
+	{labels[status]}
+</span>

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { base } from '$app/paths';
+	import '../app.css';
 
 	let { children } = $props();
 
@@ -7,105 +8,28 @@
 		{ href: `${base}/`, label: 'Home' },
 		{ href: `${base}/devices`, label: 'Devices' },
 		{ href: `${base}/guides`, label: 'Guides' },
-		{ href: `${base}/curriculum`, label: 'Curriculum' },
 		{ href: `${base}/architecture`, label: 'Architecture' }
 	];
 </script>
 
-<div class="app">
-	<header>
-		<nav>
-			<a href="{base}/" class="logo">LA-Mesh</a>
-			<ul>
+<div class="flex flex-col min-h-screen bg-surface-900 text-surface-50">
+	<header class="bg-surface-950 px-8">
+		<nav class="flex items-center max-w-[1200px] mx-auto py-4 gap-8">
+			<a href="{base}/" class="text-2xl font-bold font-mono text-primary-400 no-underline">LA-Mesh</a>
+			<ul class="flex list-none m-0 p-0 gap-6">
 				{#each nav as item}
-					<li><a href={item.href}>{item.label}</a></li>
+					<li><a href={item.href} class="text-surface-400 no-underline text-sm hover:text-primary-400 transition-colors">{item.label}</a></li>
 				{/each}
 			</ul>
 		</nav>
 	</header>
 
-	<main>
+	<main class="flex-1 max-w-[1200px] mx-auto p-8 w-full box-border">
 		{@render children()}
 	</main>
 
-	<footer>
+	<footer class="bg-surface-950 text-surface-500 text-center p-8 text-sm">
 		<p>LA-Mesh - Community LoRa mesh network for Southern Maine</p>
-		<p><a href="https://github.com/Jesssullivan/LA-Mesh">GitHub</a></p>
+		<p><a href="https://github.com/Jesssullivan/LA-Mesh" class="text-primary-400">GitHub</a></p>
 	</footer>
 </div>
-
-<style>
-	:global(body) {
-		margin: 0;
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-		color: #1a1a1a;
-		background: #fafafa;
-	}
-
-	.app {
-		display: flex;
-		flex-direction: column;
-		min-height: 100vh;
-	}
-
-	header {
-		background: #1a1a2e;
-		color: white;
-		padding: 0 2rem;
-	}
-
-	nav {
-		display: flex;
-		align-items: center;
-		max-width: 1200px;
-		margin: 0 auto;
-		padding: 1rem 0;
-		gap: 2rem;
-	}
-
-	.logo {
-		font-size: 1.5rem;
-		font-weight: bold;
-		color: #00d4aa;
-		text-decoration: none;
-	}
-
-	ul {
-		display: flex;
-		list-style: none;
-		margin: 0;
-		padding: 0;
-		gap: 1.5rem;
-	}
-
-	ul a {
-		color: #ccc;
-		text-decoration: none;
-		font-size: 0.9rem;
-	}
-
-	ul a:hover {
-		color: #00d4aa;
-	}
-
-	main {
-		flex: 1;
-		max-width: 1200px;
-		margin: 0 auto;
-		padding: 2rem;
-		width: 100%;
-		box-sizing: border-box;
-	}
-
-	footer {
-		background: #1a1a2e;
-		color: #888;
-		text-align: center;
-		padding: 2rem;
-		font-size: 0.85rem;
-	}
-
-	footer a {
-		color: #00d4aa;
-	}
-</style>

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -1,204 +1,183 @@
 <script>
 	import { base } from '$app/paths';
+	import StatusBadge from '$lib/components/StatusBadge.svelte';
 </script>
 
 <svelte:head>
 	<title>LA-Mesh - Community LoRa Mesh Network</title>
 </svelte:head>
 
-<section class="hero">
-	<h1>LA-Mesh</h1>
-	<p class="tagline">Community LoRa mesh network for Southern Maine</p>
-	<p>
+<!-- Hero -->
+<section class="text-center py-12 border-b border-surface-700 mb-8">
+	<h1 class="text-5xl font-bold font-mono text-primary-400 m-0">LA-Mesh</h1>
+	<p class="text-xl text-surface-400 mt-2 mb-4">Community LoRa mesh network for Southern Maine</p>
+	<p class="text-surface-300">
 		Encrypted mesh communications for the Lewiston-Auburn area.
 		Infrastructure-independent, resilient, community-owned.
 	</p>
-	<p class="workshops">Free fortnightly workshops in the L-A area -- from mesh basics to TEMPEST and TAILS.</p>
+	<div class="flex justify-center gap-3 mt-6 flex-wrap">
+		<img src="https://github.com/Jesssullivan/LA-Mesh/actions/workflows/build-firmware.yml/badge.svg" alt="Build Firmware" class="h-5" />
+		<img src="https://github.com/Jesssullivan/LA-Mesh/actions/workflows/deploy-pages.yml/badge.svg" alt="Deploy Pages" class="h-5" />
+		<img src="https://github.com/Jesssullivan/LA-Mesh/actions/workflows/ci.yml/badge.svg" alt="CI" class="h-5" />
+	</div>
 </section>
 
-<section class="cards">
-	<a href="{base}/guides/community-onboarding" class="card">
-		<h2>Join the Mesh</h2>
-		<p>Get a device, learn the basics, start communicating</p>
+<!-- Nav Cards -->
+<section class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
+	<a href="{base}/guides/community-onboarding" class="p-6 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Join the Mesh</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Get a device, learn the basics, start communicating</p>
 	</a>
 
-	<a href="{base}/devices" class="card">
-		<h2>Devices</h2>
-		<p>Station G2, T-Deck Plus/Pro, MeshAdv-Mini, HackRF</p>
+	<a href="{base}/devices" class="p-6 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Devices</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Station G2, T-Deck Plus/Pro, MeshAdv-Mini, HackRF</p>
 	</a>
 
-	<a href="{base}/curriculum" class="card">
-		<h2>Learn</h2>
-		<p>Workshops: mesh basics, encryption, SDR, TEMPEST, TAILS</p>
-	</a>
-
-	<a href="{base}/architecture" class="card">
-		<h2>Architecture</h2>
-		<p>Network topology, ADRs, protocol comparison, bridge design</p>
+	<a href="{base}/architecture" class="p-6 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Architecture</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Network topology, ADRs, protocol comparison, bridge design</p>
 	</a>
 </section>
 
-<section class="features">
-	<h2>What We Build</h2>
-	<div class="feature-grid">
-		<div>
-			<h3>Encrypted Mesh</h3>
-			<p>AES-256-CTR channel encryption + X25519 PKC for direct messages. No internet, no cell towers, no central authority. PSKs shared face-to-face only.</p>
+<!-- Firmware Status -->
+<section class="mb-12">
+	<h2 class="text-center text-surface-50 mb-6">Firmware Status</h2>
+	<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+		<div class="p-4 bg-surface-800 border border-surface-700 rounded-lg">
+			<span class="text-xs text-surface-500 uppercase tracking-wider">Version</span>
+			<p class="font-mono text-primary-400 text-lg m-0 mt-1">v2.7.15</p>
 		</div>
-		<div>
-			<h3>Relay Infrastructure</h3>
-			<p>Station G2 nodes (30 dBm, 36 dBm EIRP) on rooftops and towers. Hub-and-spoke topology with mesh fallback. Solar-powered for year-round operation.</p>
+		<div class="p-4 bg-surface-800 border border-surface-700 rounded-lg">
+			<span class="text-xs text-surface-500 uppercase tracking-wider">Min Required</span>
+			<p class="font-mono text-primary-400 text-lg m-0 mt-1">v2.7.15+</p>
 		</div>
-		<div>
-			<h3>SMS/Email Bridge</h3>
-			<p>MeshAdv-Mini Pi HAT running meshtasticd, Mosquitto MQTT, SMS/email gateway (in development), and GPG-signed email bridge. Mesh-to-internet gateway.</p>
+		<div class="p-4 bg-surface-800 border border-surface-700 rounded-lg">
+			<span class="text-xs text-surface-500 uppercase tracking-wider">Build Source</span>
+			<p class="font-mono text-primary-400 text-lg m-0 mt-1">Custom (LA-Mesh)</p>
 		</div>
-		<div>
-			<h3>RF Education</h3>
-			<p>Hands-on workshops: mesh basics, security, SDR with HackRF H4M, TEMPEST, TAILS integration. FCC Part 15 compliance, link budget calculations, protocol analysis.</p>
+		<div class="p-4 bg-surface-800 border border-surface-700 rounded-lg">
+			<span class="text-xs text-surface-500 uppercase tracking-wider">Target</span>
+			<p class="font-mono text-primary-400 text-lg m-0 mt-1">station-g2</p>
 		</div>
 	</div>
 </section>
 
-<section class="network-status">
-	<h2>Network Configuration</h2>
-	<div class="config-grid">
-		<div class="config-item">
-			<span class="label">Region</span>
-			<span class="value">US (915 MHz ISM)</span>
-		</div>
-		<div class="config-item">
-			<span class="label">Modem Preset</span>
-			<span class="value">LONG_FAST</span>
-		</div>
-		<div class="config-item">
-			<span class="label">Hop Limit</span>
-			<span class="value">5</span>
-		</div>
-		<div class="config-item">
-			<span class="label">Channels</span>
-			<span class="value">LA-Mesh / LA-Admin / LA-Emergency</span>
-		</div>
-		<div class="config-item">
-			<span class="label">Encryption</span>
-			<span class="value">AES-256-CTR (channel) + PKC (DMs)</span>
-		</div>
-		<div class="config-item">
-			<span class="label">Min Firmware</span>
-			<span class="value">v2.7.15+ (CVE-2025-52464, CVE-2025-24797 fixes)</span>
-		</div>
+<!-- Clone to Flash -->
+<section class="mb-12">
+	<h2 class="text-center text-surface-50 mb-6">Clone to Flash</h2>
+	<div class="p-6 bg-surface-800 border border-surface-700 rounded-lg overflow-x-auto">
+		<pre class="font-mono text-sm text-surface-200 leading-relaxed m-0"><code><span class="text-surface-500"># Clone and enter the repo</span>
+git clone https://github.com/Jesssullivan/LA-Mesh.git && cd LA-Mesh
+
+<span class="text-surface-500"># Enter nix devshell (provides meshtastic, esptool, jq)</span>
+nix develop
+
+<span class="text-surface-500"># Setup and fetch firmware</span>
+just setup
+just fetch-firmware
+
+<span class="text-surface-500"># Flash and configure a Station G2</span>
+just flash-g2
+just configure-g2
+just mesh-set-role</code></pre>
 	</div>
 </section>
 
-<style>
-	.hero {
-		text-align: center;
-		padding: 3rem 0;
-		border-bottom: 1px solid #eee;
-		margin-bottom: 2rem;
-	}
+<!-- Justfile Quick Reference -->
+<section class="mb-12">
+	<h2 class="text-center text-surface-50 mb-6">Justfile Quick Reference</h2>
+	<div class="overflow-x-auto">
+		<table class="w-full border-collapse">
+			<thead>
+				<tr>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Command</th>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Description</th>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Status</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr class="border-b border-surface-700">
+					<td class="p-3 font-mono text-primary-400 text-sm">just setup</td>
+					<td class="p-3 text-surface-200 text-sm">Install tools and verify environment</td>
+					<td class="p-3"><StatusBadge status="working" /></td>
+				</tr>
+				<tr class="border-b border-surface-700">
+					<td class="p-3 font-mono text-primary-400 text-sm">just fetch-firmware</td>
+					<td class="p-3 text-surface-200 text-sm">Download and verify firmware binaries</td>
+					<td class="p-3"><StatusBadge status="working" /></td>
+				</tr>
+				<tr class="border-b border-surface-700">
+					<td class="p-3 font-mono text-primary-400 text-sm">just flash-g2</td>
+					<td class="p-3 text-surface-200 text-sm">Flash Station G2 (erase + 3-partition write)</td>
+					<td class="p-3"><StatusBadge status="working" /></td>
+				</tr>
+				<tr class="border-b border-surface-700">
+					<td class="p-3 font-mono text-primary-400 text-sm">just configure-g2</td>
+					<td class="p-3 text-surface-200 text-sm">Apply profile + channels to Station G2</td>
+					<td class="p-3"><StatusBadge status="working" /></td>
+				</tr>
+				<tr class="border-b border-surface-700">
+					<td class="p-3 font-mono text-primary-400 text-sm">just mesh-set-role</td>
+					<td class="p-3 text-surface-200 text-sm">Set ROUTER role (do last -- kills USB)</td>
+					<td class="p-3"><StatusBadge status="working" /></td>
+				</tr>
+				<tr class="border-b border-surface-700">
+					<td class="p-3 font-mono text-primary-400 text-sm">just flash-tdeck</td>
+					<td class="p-3 text-surface-200 text-sm">Flash T-Deck Plus client</td>
+					<td class="p-3"><StatusBadge status="planned" /></td>
+				</tr>
+				<tr class="border-b border-surface-700">
+					<td class="p-3 font-mono text-primary-400 text-sm">just build-firmware</td>
+					<td class="p-3 text-surface-200 text-sm">Build custom firmware from source</td>
+					<td class="p-3"><StatusBadge status="working" /></td>
+				</tr>
+				<tr>
+					<td class="p-3 font-mono text-primary-400 text-sm">just bridge-setup</td>
+					<td class="p-3 text-surface-200 text-sm">Configure SMS/Email bridge on Pi</td>
+					<td class="p-3"><StatusBadge status="planned" /></td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</section>
 
-	h1 {
-		font-size: 3rem;
-		margin: 0;
-		color: #1a1a2e;
-	}
-
-	.tagline {
-		font-size: 1.3rem;
-		color: #666;
-		margin: 0.5rem 0 1rem;
-	}
-
-	.workshops {
-		font-size: 1rem;
-		color: #00d4aa;
-		font-weight: 600;
-		margin-top: 0.5rem;
-	}
-
-	.cards {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-		gap: 1.5rem;
-		margin-bottom: 3rem;
-	}
-
-	.card {
-		padding: 1.5rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		text-decoration: none;
-		color: inherit;
-		transition: border-color 0.2s, box-shadow 0.2s;
-	}
-
-	.card:hover {
-		border-color: #00d4aa;
-		box-shadow: 0 2px 8px rgba(0, 212, 170, 0.15);
-	}
-
-	.card h2 {
-		margin: 0 0 0.5rem;
-		color: #1a1a2e;
-	}
-
-	.card p {
-		margin: 0;
-		color: #666;
-	}
-
-	.features h2 {
-		text-align: center;
-		margin-bottom: 2rem;
-	}
-
-	.feature-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-		gap: 2rem;
-		margin-bottom: 3rem;
-	}
-
-	.feature-grid h3 {
-		color: #00d4aa;
-		margin-bottom: 0.5rem;
-	}
-
-	.feature-grid p {
-		color: #555;
-		line-height: 1.6;
-	}
-
-	.network-status h2 {
-		text-align: center;
-		margin-bottom: 1.5rem;
-	}
-
-	.config-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-		gap: 0.75rem;
-	}
-
-	.config-item {
-		display: flex;
-		justify-content: space-between;
-		padding: 0.75rem 1rem;
-		background: #f9f9f9;
-		border-radius: 6px;
-		border-left: 3px solid #00d4aa;
-	}
-
-	.label {
-		font-weight: 600;
-		color: #555;
-		font-size: 0.9rem;
-	}
-
-	.value {
-		color: #1a1a2e;
-		font-family: monospace;
-		font-size: 0.9rem;
-	}
-</style>
+<!-- Network Configuration -->
+<section class="mb-8">
+	<h2 class="text-center text-surface-50 mb-6">Network Configuration</h2>
+	<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+		<div class="flex justify-between p-3 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<span class="font-semibold text-surface-400 text-sm">Region</span>
+			<span class="font-mono text-surface-200 text-sm">US (915 MHz ISM)</span>
+		</div>
+		<div class="flex justify-between p-3 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<span class="font-semibold text-surface-400 text-sm">Modem Preset</span>
+			<span class="font-mono text-surface-200 text-sm">LONG_FAST</span>
+		</div>
+		<div class="flex justify-between p-3 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<span class="font-semibold text-surface-400 text-sm">Hop Limit</span>
+			<span class="font-mono text-surface-200 text-sm">5</span>
+		</div>
+		<div class="flex justify-between p-3 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<span class="font-semibold text-surface-400 text-sm">Channels</span>
+			<span class="font-mono text-surface-200 text-sm">LA-Mesh / LA-Admin / LA-Emergcy</span>
+		</div>
+		<div class="flex justify-between p-3 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<span class="font-semibold text-surface-400 text-sm">Encryption</span>
+			<span class="font-mono text-surface-200 text-sm">AES-256-CTR + PKC (DMs)</span>
+		</div>
+		<div class="flex justify-between p-3 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<span class="font-semibold text-surface-400 text-sm">Min Firmware</span>
+			<span class="font-mono text-surface-200 text-sm">v2.7.15+</span>
+		</div>
+	</div>
+</section>

--- a/site/src/routes/architecture/+page.svelte
+++ b/site/src/routes/architecture/+page.svelte
@@ -12,13 +12,20 @@
 		const { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs');
 		mermaid.initialize({
 			startOnLoad: false,
-			theme: 'base',
+			theme: 'dark',
 			themeVariables: {
-				primaryColor: '#1a1a2e',
-				primaryTextColor: '#00d4aa',
-				lineColor: '#00d4aa',
-				secondaryColor: '#f5f5f5',
-				tertiaryColor: '#fff'
+				primaryColor: '#1e293b',
+				primaryTextColor: '#e2e8f0',
+				primaryBorderColor: '#475569',
+				lineColor: '#22d3ee',
+				secondaryColor: '#0f172a',
+				tertiaryColor: '#1e293b',
+				background: '#0f172a',
+				mainBkg: '#1e293b',
+				nodeBorder: '#475569',
+				clusterBkg: '#0f172a',
+				titleColor: '#e2e8f0',
+				edgeLabelBackground: '#1e293b'
 			}
 		});
 		if (topologyEl) {
@@ -36,14 +43,14 @@
 	<title>Architecture - LA-Mesh</title>
 </svelte:head>
 
-<h1>Architecture</h1>
-<p>Technical decisions and network design for LA-Mesh.</p>
+<h1 class="text-3xl font-bold text-surface-50 mb-2">Architecture</h1>
+<p class="text-surface-400 mb-8">Technical decisions and network design for LA-Mesh.</p>
 
-<section>
-	<h2>Network Topology</h2>
-	<p>Hub-and-spoke with mesh redundancy. High-power Station G2 routers on elevated sites provide backbone coverage, T-Deck clients form the user-facing mesh, and MeshAdv-Mini Pi HAT handles bridge/gateway duties.</p>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Network Topology</h2>
+	<p class="text-surface-300 mb-4">Hub-and-spoke with mesh redundancy. High-power Station G2 routers on elevated sites provide backbone coverage, T-Deck clients form the user-facing mesh, and MeshAdv-Mini Pi HAT handles bridge/gateway duties.</p>
 
-	<div class="mermaid-container" bind:this={topologyEl}
+	<div class="overflow-x-auto my-6" bind:this={topologyEl}
 		data-graph={`graph TD
 		INET["INTERNET / MQTT"]
 		GW["MeshAdv-Mini Gateway\nmeshtasticd + bridges\nROUTER_CLIENT"]
@@ -62,104 +69,117 @@
 		R1 --- C3
 		R2 --- C4
 		R2 --- C5`}>
-		<pre class="diagram">Loading diagram...</pre>
+		<pre class="bg-surface-800 text-primary-400 p-6 rounded-lg overflow-x-auto text-sm leading-relaxed">Loading diagram...</pre>
 	</div>
 
-	<div class="specs">
-		<div class="spec">
-			<h4>Station G2 Link Budget</h4>
-			<p>30 dBm TX + 6 dBi antenna = 36 dBm EIRP. Max path loss: 171 dB. Estimated range: 20+ km line-of-sight.</p>
+	<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
+		<div class="p-4 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<h4 class="text-surface-50 font-semibold m-0 mb-2">Station G2 Link Budget</h4>
+			<p class="text-surface-400 text-sm m-0">30 dBm TX + 6 dBi antenna = 36 dBm EIRP. Max path loss: 171 dB. Estimated range: 20+ km line-of-sight.</p>
 		</div>
-		<div class="spec">
-			<h4>T-Deck Link Budget</h4>
-			<p>22 dBm TX + 2 dBi antenna = 24 dBm EIRP. Max path loss: 160 dB. Estimated range: 5-10 km line-of-sight.</p>
+		<div class="p-4 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<h4 class="text-surface-50 font-semibold m-0 mb-2">T-Deck Link Budget</h4>
+			<p class="text-surface-400 text-sm m-0">22 dBm TX + 2 dBi antenna = 24 dBm EIRP. Max path loss: 160 dB. Estimated range: 5-10 km line-of-sight.</p>
 		</div>
-		<div class="spec">
-			<h4>Hop Limit</h4>
-			<p>Set to 5 (optimized for LA-Mesh coverage area). Higher than default 3 to ensure full L-A area reach.</p>
-		</div>
-	</div>
-</section>
-
-<section>
-	<h2>Channel Architecture</h2>
-	<table>
-		<thead>
-			<tr><th>Index</th><th>Channel</th><th>Purpose</th><th>PSK</th></tr>
-		</thead>
-		<tbody>
-			<tr><td>0</td><td>LA-Mesh</td><td>Primary community channel</td><td>Unique 256-bit (shared in-person)</td></tr>
-			<tr><td>1</td><td>LA-Admin</td><td>Operator coordination</td><td>Separate unique 256-bit</td></tr>
-			<tr><td>2</td><td>LA-Emergency</td><td>Emergency use only</td><td>Separate unique 256-bit</td></tr>
-		</tbody>
-	</table>
-	<p class="note">PSKs are never transmitted digitally. Shared face-to-face at community meetups and rotated quarterly.</p>
-</section>
-
-<section>
-	<h2>Decision Records</h2>
-	<div class="adr-list">
-		<div class="adr">
-			<span class="adr-id">ADR-001</span>
-			<h3>Primary Firmware: Meshtastic</h3>
-			<p>Meshtastic chosen for ecosystem maturity, MQTT bridge support, AES-256-CTR + X25519 PKC encryption. MeshCore evaluated on single device.</p>
-			<span class="adr-status accepted">Accepted</span>
-		</div>
-
-		<div class="adr">
-			<span class="adr-id">ADR-002</span>
-			<h3>MeshCore Evaluation Scope</h3>
-			<p>Single Station G2 running MeshCore for evaluation against 5 criteria: stability, routing efficiency, room server, companion app UX, AMMB bridge.</p>
-			<span class="adr-status accepted">Accepted</span>
-		</div>
-
-		<div class="adr">
-			<span class="adr-id">ADR-003</span>
-			<h3>Hub-and-Spoke with Mesh Redundancy</h3>
-			<p>Station G2 routers on elevated sites as backbone. Hop limit 5 for full coverage. Mesh fallback when routers unreachable.</p>
-			<span class="adr-status accepted">Accepted</span>
-		</div>
-
-		<div class="adr">
-			<span class="adr-id">ADR-004</span>
-			<h3>3-Channel Encryption Scheme</h3>
-			<p>Primary, admin, and emergency channels with unique PSKs. PKC enabled for DMs. Quarterly rotation. CVE-2025-52464 firmware requirement.</p>
-			<span class="adr-status accepted">Accepted</span>
-		</div>
-
-		<div class="adr">
-			<span class="adr-id">ADR-005</span>
-			<h3>Self-Hosted MQTT Broker</h3>
-			<p>Mosquitto on Raspberry Pi (MeshAdv-Mini gateway). Full control, no external dependency, free, enables local-first bridge architecture.</p>
-			<span class="adr-status accepted">Accepted</span>
+		<div class="p-4 bg-surface-800 rounded-lg border-l-3 border-primary-500">
+			<h4 class="text-surface-50 font-semibold m-0 mb-2">Hop Limit</h4>
+			<p class="text-surface-400 text-sm m-0">Set to 5 (optimized for LA-Mesh coverage area). Higher than default 3 to ensure full L-A area reach.</p>
 		</div>
 	</div>
 </section>
 
-<section>
-	<h2>Protocol Comparison</h2>
-	<table>
-		<thead>
-			<tr><th>Aspect</th><th>Meshtastic</th><th>MeshCore</th></tr>
-		</thead>
-		<tbody>
-			<tr><td>Encryption</td><td>AES-256-CTR + X25519 PKC</td><td>AES-128-ECB (ChaChaPoly AEAD coming)</td></tr>
-			<tr><td>Routing</td><td>Managed flood + next-hop DMs</td><td>Hybrid flood-then-direct</td></tr>
-			<tr><td>Max Hops</td><td>7 (configurable)</td><td>64</td></tr>
-			<tr><td>MQTT Bridge</td><td>Built-in (native)</td><td>Third-party only</td></tr>
-			<tr><td>PKC (DMs)</td><td>X25519 + AES-256-CCM</td><td>Ed25519 + ECDH + AES-128</td></tr>
-			<tr><td>Device Support</td><td>100+ devices, all major vendors</td><td>65+ devices, growing</td></tr>
-			<tr><td>Client Repeating</td><td>All roles can repeat</td><td>Clients never repeat (by design)</td></tr>
-			<tr><td>Room Server</td><td>No equivalent</td><td>Dedicated always-on relay with history</td></tr>
-			<tr><td>CVE-2025-52464</td><td>Fixed in v2.7.15+</td><td>Not affected (different key model)</td></tr>
-			<tr><td>Interop</td><td colspan="2">NOT compatible -- separate protocols, AMMB bridge for limited interop</td></tr>
-		</tbody>
-	</table>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Channel Architecture</h2>
+	<div class="overflow-x-auto">
+		<table class="w-full border-collapse mt-4">
+			<thead>
+				<tr>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Index</th>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Channel</th>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Purpose</th>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">PSK</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200">0</td><td class="p-3 text-surface-200 font-mono">LA-Mesh</td><td class="p-3 text-surface-200">Primary community channel</td><td class="p-3 text-surface-200">Unique 256-bit (shared in-person)</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200">1</td><td class="p-3 text-surface-200 font-mono">LA-Admin</td><td class="p-3 text-surface-200">Operator coordination</td><td class="p-3 text-surface-200">Separate unique 256-bit</td></tr>
+				<tr><td class="p-3 text-surface-200">2</td><td class="p-3 text-surface-200 font-mono">LA-Emergcy</td><td class="p-3 text-surface-200">Emergency use only</td><td class="p-3 text-surface-200">Separate unique 256-bit</td></tr>
+			</tbody>
+		</table>
+	</div>
+	<p class="text-sm text-surface-500 italic mt-2">PSKs are never transmitted digitally. Shared face-to-face at community meetups and rotated quarterly.</p>
 </section>
 
-<section>
-	<h2>Bridge Architecture</h2>
-	<div class="mermaid-container" bind:this={bridgeEl}
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Decision Records</h2>
+	<div class="grid gap-4 mt-4">
+		<div class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<span class="font-mono text-sm text-surface-500">ADR-001</span>
+			<h3 class="text-surface-50 font-semibold mt-1 mb-2">Primary Firmware: Meshtastic</h3>
+			<p class="text-surface-400 text-sm m-0 mb-2">Meshtastic chosen for ecosystem maturity, MQTT bridge support, AES-256-CTR + X25519 PKC encryption. MeshCore evaluated on single device.</p>
+			<span class="px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-400">Accepted</span>
+		</div>
+
+		<div class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<span class="font-mono text-sm text-surface-500">ADR-002</span>
+			<h3 class="text-surface-50 font-semibold mt-1 mb-2">MeshCore Evaluation Scope</h3>
+			<p class="text-surface-400 text-sm m-0 mb-2">Single Station G2 running MeshCore for evaluation against 5 criteria: stability, routing efficiency, room server, companion app UX, AMMB bridge.</p>
+			<span class="px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-400">Accepted</span>
+		</div>
+
+		<div class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<span class="font-mono text-sm text-surface-500">ADR-003</span>
+			<h3 class="text-surface-50 font-semibold mt-1 mb-2">Hub-and-Spoke with Mesh Redundancy</h3>
+			<p class="text-surface-400 text-sm m-0 mb-2">Station G2 routers on elevated sites as backbone. Hop limit 5 for full coverage. Mesh fallback when routers unreachable.</p>
+			<span class="px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-400">Accepted</span>
+		</div>
+
+		<div class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<span class="font-mono text-sm text-surface-500">ADR-004</span>
+			<h3 class="text-surface-50 font-semibold mt-1 mb-2">3-Channel Encryption Scheme</h3>
+			<p class="text-surface-400 text-sm m-0 mb-2">Primary, admin, and emergency channels with unique PSKs. PKC enabled for DMs. Quarterly rotation. CVE-2025-52464 firmware requirement.</p>
+			<span class="px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-400">Accepted</span>
+		</div>
+
+		<div class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<span class="font-mono text-sm text-surface-500">ADR-005</span>
+			<h3 class="text-surface-50 font-semibold mt-1 mb-2">Self-Hosted MQTT Broker</h3>
+			<p class="text-surface-400 text-sm m-0 mb-2">Mosquitto on Raspberry Pi (MeshAdv-Mini gateway). Full control, no external dependency, free, enables local-first bridge architecture.</p>
+			<span class="px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-400">Accepted</span>
+		</div>
+	</div>
+</section>
+
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Protocol Comparison</h2>
+	<div class="overflow-x-auto">
+		<table class="w-full border-collapse mt-4">
+			<thead>
+				<tr>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Aspect</th>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Meshtastic</th>
+					<th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">MeshCore</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">Encryption</td><td class="p-3 text-surface-200">AES-256-CTR + X25519 PKC</td><td class="p-3 text-surface-200">AES-128-ECB (ChaChaPoly AEAD coming)</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">Routing</td><td class="p-3 text-surface-200">Managed flood + next-hop DMs</td><td class="p-3 text-surface-200">Hybrid flood-then-direct</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">Max Hops</td><td class="p-3 text-surface-200">7 (configurable)</td><td class="p-3 text-surface-200">64</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">MQTT Bridge</td><td class="p-3 text-surface-200">Built-in (native)</td><td class="p-3 text-surface-200">Third-party only</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">PKC (DMs)</td><td class="p-3 text-surface-200">X25519 + AES-256-CCM</td><td class="p-3 text-surface-200">Ed25519 + ECDH + AES-128</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">Device Support</td><td class="p-3 text-surface-200">100+ devices, all major vendors</td><td class="p-3 text-surface-200">65+ devices, growing</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">Client Repeating</td><td class="p-3 text-surface-200">All roles can repeat</td><td class="p-3 text-surface-200">Clients never repeat (by design)</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">Room Server</td><td class="p-3 text-surface-200">No equivalent</td><td class="p-3 text-surface-200">Dedicated always-on relay with history</td></tr>
+				<tr class="border-b border-surface-700"><td class="p-3 text-surface-200 font-semibold">CVE-2025-52464</td><td class="p-3 text-surface-200">Fixed in v2.7.15+</td><td class="p-3 text-surface-200">Not affected (different key model)</td></tr>
+				<tr><td class="p-3 text-surface-200 font-semibold">Interop</td><td class="p-3 text-surface-200" colspan="2">NOT compatible -- separate protocols, AMMB bridge for limited interop</td></tr>
+			</tbody>
+		</table>
+	</div>
+</section>
+
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Bridge Architecture</h2>
+	<div class="overflow-x-auto my-6" bind:this={bridgeEl}
 		data-graph={`graph TD
 		MESH["Mesh Devices"]
 		GW["MeshAdv-Mini Gateway"]
@@ -180,122 +200,14 @@
 		EMAIL --- SMTPGW
 		SMSGW --- CELL
 		SMTPGW --- NET`}>
-		<pre class="diagram">Loading diagram...</pre>
+		<pre class="bg-surface-800 text-primary-400 p-6 rounded-lg overflow-x-auto text-sm leading-relaxed">Loading diagram...</pre>
 	</div>
 </section>
 
 <style>
-	section {
-		margin-bottom: 3rem;
-	}
-
-	.diagram {
-		background: #1a1a2e;
-		color: #00d4aa;
-		padding: 1.5rem;
-		border-radius: 8px;
-		overflow-x: auto;
-		font-size: 0.8rem;
-		line-height: 1.4;
-	}
-
-	.mermaid-container {
-		overflow-x: auto;
-		margin: 1.5rem 0;
-	}
-
-	.mermaid-container :global(svg) {
+	:global(.mermaid-container svg),
+	:global(div[data-graph] svg) {
 		max-width: 100%;
 		height: auto;
-	}
-
-	.specs {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-		gap: 1rem;
-		margin-top: 1.5rem;
-	}
-
-	.spec {
-		padding: 1rem;
-		background: #f9f9f9;
-		border-radius: 6px;
-		border-left: 3px solid #00d4aa;
-	}
-
-	.spec h4 {
-		margin: 0 0 0.5rem;
-		color: #1a1a2e;
-	}
-
-	.spec p {
-		margin: 0;
-		font-size: 0.9rem;
-		color: #555;
-	}
-
-	.note {
-		font-size: 0.85rem;
-		color: #888;
-		font-style: italic;
-		margin-top: 0.5rem;
-	}
-
-	.adr-list {
-		display: grid;
-		gap: 1rem;
-		margin-top: 1rem;
-	}
-
-	.adr {
-		padding: 1rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		background: white;
-	}
-
-	.adr-id {
-		font-family: monospace;
-		font-size: 0.85rem;
-		color: #888;
-	}
-
-	.adr h3 {
-		margin: 0.25rem 0 0.5rem;
-	}
-
-	.adr p {
-		margin: 0 0 0.5rem;
-		color: #555;
-		font-size: 0.9rem;
-	}
-
-	.adr-status {
-		display: inline-block;
-		padding: 0.1rem 0.4rem;
-		border-radius: 3px;
-		font-size: 0.75rem;
-		color: white;
-	}
-
-	.adr-status.accepted {
-		background: #00d4aa;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-		margin-top: 1rem;
-	}
-
-	th, td {
-		padding: 0.75rem;
-		border: 1px solid #ddd;
-		text-align: left;
-	}
-
-	th {
-		background: #f5f5f5;
-		font-weight: 600;
 	}
 </style>

--- a/site/src/routes/curriculum/+page.svelte
+++ b/site/src/routes/curriculum/+page.svelte
@@ -6,193 +6,106 @@
 	<title>Curriculum - LA-Mesh</title>
 </svelte:head>
 
-<h1>Curriculum</h1>
-<p>Hands-on workshops in mesh networking, RF engineering, and secure communications. Pick any topic that interests you. All workshops are free. We meet fortnightly in the L-A area.</p>
+<h1 class="text-3xl font-bold text-surface-50 mb-2">Curriculum</h1>
 
-<div class="levels">
-	<a href="{base}/curriculum/mesh-basics" class="level">
-		<div class="level-header">
-			<span class="badge">Fundamentals</span>
-			<h2>Mesh Basics</h2>
-		</div>
-		<p>6-part workshop covering mesh networking fundamentals and hands-on device setup.</p>
-		<ul>
-			<li>What is a mesh network? Topology, resilience, real-world applications</li>
-			<li>LoRa radio: chirp spread spectrum, 915 MHz ISM, range vs data rate tradeoffs</li>
-			<li>First message: power on, pair, send and receive on LA-Mesh</li>
-			<li>Routing: hops, RSSI, SNR, how messages traverse the mesh</li>
-			<li>Channels and encryption: AES-256, PSK, what "encrypted" really means</li>
-		</ul>
-		<div class="meta">
-			<span>2-hour workshop</span>
-		</div>
-		<span class="status">Available</span>
-	</a>
-
-	<a href="{base}/curriculum/security" class="level">
-		<div class="level-header">
-			<span class="badge">Security</span>
-			<h2>Encryption and Security</h2>
-		</div>
-		<p>5-part workshop on the full encryption stack, threat modeling, and operational security.</p>
-		<ul>
-			<li>3-layer encryption model: LoRa physical, AES-256-CTR channel, X25519 PKC for DMs</li>
-			<li>PSK management: generation, secure distribution, rotation ceremony</li>
-			<li>Case study: CVE-2025-52464 (duplicate crypto keys from vendor cloning)</li>
-			<li>Threat modeling: actor/capability matrix for realistic adversary assessment</li>
-			<li>OpSec practices: metadata awareness, position sharing, TAILS integration</li>
-		</ul>
-		<div class="meta">
-			<span>4-hour workshop</span>
-		</div>
-		<span class="status">Available</span>
-	</a>
-
-	<a href="{base}/curriculum/sdr" class="level">
-		<div class="level-header">
-			<span class="badge">SDR / RF</span>
-			<h2>SDR and RF Engineering</h2>
-		</div>
-		<p>7-part lab using HackRF H4M for hands-on RF analysis and LoRa protocol dissection.</p>
-		<ul>
-			<li>SDR fundamentals: sampling, Nyquist, quadrature, dynamic range</li>
-			<li>FCC Part 15.247: legal limits (30 dBm conducted, 36 dBm EIRP at 915 MHz)</li>
-			<li>Live spectrum observation: RTL-SDR waterfall of 915 MHz band</li>
-			<li>LoRa signal anatomy: chirp structure, spreading factors, bandwidth, coding rate</li>
-			<li>GNU Radio + gr-lora_sdr: building a LoRa receiver flowgraph</li>
-			<li>RF troubleshooting: link budget calculations, antenna patterns, path loss</li>
-			<li>LoRa protocol analysis with gr-lora_sdr and Meshtastic_SDR</li>
-		</ul>
-		<div class="meta">
-			<span>6 hours (two 3-hour sessions)</span>
-			<span>HackRF H4M provided</span>
-		</div>
-		<span class="status">Available</span>
-	</a>
-
-	<a href="{base}/curriculum/tempest" class="level">
-		<div class="level-header">
-			<span class="badge">EMSEC</span>
-			<h2>TEMPEST and Emanation Security</h2>
-		</div>
-		<p>3-hour lab on electromagnetic emanation analysis using HackRF H4M and PortaPack Mayhem.</p>
-		<ul>
-			<li>Emanation theory: Van Eck phreaking, video signal reconstruction</li>
-			<li>Lab: spectrum survey with PortaPack Looking Glass</li>
-			<li>Lab: VGA reconstruction with TempestSDR + HackRF</li>
-			<li>Lab: HDMI capture with deep-tempest CNN enhancement</li>
-			<li>Keyboard emanations, countermeasures, mesh implications</li>
-		</ul>
-		<div class="meta">
-			<span>3-hour lab</span>
-			<span>HackRF H4M provided</span>
-		</div>
-		<span class="status">Available</span>
-	</a>
-
-	<a href="{base}/curriculum/tails" class="level">
-		<div class="level-header">
-			<span class="badge">Privacy</span>
-			<h2>TAILS and Secure Communications</h2>
-		</div>
-		<p>6-part lab on maximum operational security using TAILS OS with mesh networking.</p>
-		<ul>
-			<li>TAILS introduction: amnesic system, Tor routing, persistence volumes</li>
-			<li>Mesh + TAILS combination: meshtastic-cli on TAILS, air-gapped workflows</li>
-			<li>Hands-on: boot TAILS from USB, verify signatures, configure persistence</li>
-			<li>5-layer OpSec model: physical, digital, communications, behavioral, network</li>
-			<li>Practical scenarios: journalist protection, protest communications, disaster response</li>
-			<li>Honest assessment: what TAILS can and cannot protect against</li>
-		</ul>
-		<div class="meta">
-			<span>3-hour lab</span>
-			<span>USB drives provided</span>
-		</div>
-		<span class="status">Available</span>
-	</a>
+<div class="p-4 bg-yellow-500/10 border border-yellow-500/30 rounded-lg mb-8">
+	<p class="text-yellow-400 font-semibold m-0 mb-1">Being Restructured</p>
+	<p class="text-yellow-300/80 text-sm m-0">The curriculum section is being reorganized. Workshop content is moving into the guides section. The pages below are preserved but may be outdated.</p>
 </div>
 
-<style>
-	.levels {
-		display: grid;
-		gap: 1.5rem;
-		margin-top: 2rem;
-	}
+<p class="text-surface-400 mb-8">Hands-on workshops in mesh networking, RF engineering, and secure communications. Pick any topic that interests you. All workshops are free. We meet fortnightly in the L-A area.</p>
 
-	.level {
-		display: block;
-		padding: 1.5rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		background: white;
-		text-decoration: none;
-		color: inherit;
-		transition: border-color 0.2s, box-shadow 0.2s;
-	}
+<div class="grid gap-6 mt-8">
+	<a href="{base}/curriculum/mesh-basics" class="block p-6 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center gap-4 mb-3">
+			<span class="px-3 py-1 rounded text-sm font-semibold bg-surface-950 text-primary-400 whitespace-nowrap">Fundamentals</span>
+			<h2 class="text-xl font-bold text-surface-50 m-0">Mesh Basics</h2>
+		</div>
+		<p class="text-surface-400 mb-3">6-part workshop covering mesh networking fundamentals and hands-on device setup.</p>
+		<ul class="text-surface-400 text-sm pl-6 mb-4">
+			<li class="mb-1">What is a mesh network? Topology, resilience, real-world applications</li>
+			<li class="mb-1">LoRa radio: chirp spread spectrum, 915 MHz ISM, range vs data rate tradeoffs</li>
+			<li class="mb-1">First message: power on, pair, send and receive on LA-Mesh</li>
+			<li class="mb-1">Routing: hops, RSSI, SNR, how messages traverse the mesh</li>
+			<li class="mb-1">Channels and encryption: AES-256, PSK, what "encrypted" really means</li>
+		</ul>
+		<div class="flex gap-4 flex-wrap text-sm text-surface-500 mb-3">
+			<span class="bg-surface-700 px-2 py-0.5 rounded">2-hour workshop</span>
+		</div>
+	</a>
 
-	a.level:hover {
-		border-color: #00d4aa;
-		box-shadow: 0 2px 8px rgba(0, 212, 170, 0.15);
-	}
+	<a href="{base}/curriculum/security" class="block p-6 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center gap-4 mb-3">
+			<span class="px-3 py-1 rounded text-sm font-semibold bg-surface-950 text-primary-400 whitespace-nowrap">Security</span>
+			<h2 class="text-xl font-bold text-surface-50 m-0">Encryption and Security</h2>
+		</div>
+		<p class="text-surface-400 mb-3">5-part workshop on the full encryption stack, threat modeling, and operational security.</p>
+		<ul class="text-surface-400 text-sm pl-6 mb-4">
+			<li class="mb-1">3-layer encryption model: LoRa physical, AES-256-CTR channel, X25519 PKC for DMs</li>
+			<li class="mb-1">PSK management: generation, secure distribution, rotation ceremony</li>
+			<li class="mb-1">Case study: CVE-2025-52464 (duplicate crypto keys from vendor cloning)</li>
+			<li class="mb-1">Threat modeling: actor/capability matrix for realistic adversary assessment</li>
+			<li class="mb-1">OpSec practices: metadata awareness, position sharing, TAILS integration</li>
+		</ul>
+		<div class="flex gap-4 flex-wrap text-sm text-surface-500 mb-3">
+			<span class="bg-surface-700 px-2 py-0.5 rounded">4-hour workshop</span>
+		</div>
+	</a>
 
-	.level-header {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		margin-bottom: 0.75rem;
-	}
+	<a href="{base}/curriculum/sdr" class="block p-6 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center gap-4 mb-3">
+			<span class="px-3 py-1 rounded text-sm font-semibold bg-surface-950 text-primary-400 whitespace-nowrap">SDR / RF</span>
+			<h2 class="text-xl font-bold text-surface-50 m-0">SDR and RF Engineering</h2>
+		</div>
+		<p class="text-surface-400 mb-3">7-part lab using HackRF H4M for hands-on RF analysis and LoRa protocol dissection.</p>
+		<ul class="text-surface-400 text-sm pl-6 mb-4">
+			<li class="mb-1">SDR fundamentals: sampling, Nyquist, quadrature, dynamic range</li>
+			<li class="mb-1">FCC Part 15.247: legal limits (30 dBm conducted, 36 dBm EIRP at 915 MHz)</li>
+			<li class="mb-1">Live spectrum observation: RTL-SDR waterfall of 915 MHz band</li>
+			<li class="mb-1">LoRa signal anatomy: chirp structure, spreading factors, bandwidth, coding rate</li>
+			<li class="mb-1">GNU Radio + gr-lora_sdr: building a LoRa receiver flowgraph</li>
+		</ul>
+		<div class="flex gap-4 flex-wrap text-sm text-surface-500 mb-3">
+			<span class="bg-surface-700 px-2 py-0.5 rounded">6 hours (two 3-hour sessions)</span>
+			<span class="bg-surface-700 px-2 py-0.5 rounded">HackRF H4M provided</span>
+		</div>
+	</a>
 
-	.badge {
-		background: #1a1a2e;
-		color: #00d4aa;
-		padding: 0.25rem 0.75rem;
-		border-radius: 4px;
-		font-size: 0.85rem;
-		font-weight: 600;
-		white-space: nowrap;
-	}
+	<a href="{base}/curriculum/tempest" class="block p-6 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center gap-4 mb-3">
+			<span class="px-3 py-1 rounded text-sm font-semibold bg-surface-950 text-primary-400 whitespace-nowrap">EMSEC</span>
+			<h2 class="text-xl font-bold text-surface-50 m-0">TEMPEST and Emanation Security</h2>
+		</div>
+		<p class="text-surface-400 mb-3">3-hour lab on electromagnetic emanation analysis using HackRF H4M and PortaPack Mayhem.</p>
+		<ul class="text-surface-400 text-sm pl-6 mb-4">
+			<li class="mb-1">Emanation theory: Van Eck phreaking, video signal reconstruction</li>
+			<li class="mb-1">Lab: spectrum survey with PortaPack Looking Glass</li>
+			<li class="mb-1">Lab: VGA reconstruction with TempestSDR + HackRF</li>
+			<li class="mb-1">Lab: HDMI capture with deep-tempest CNN enhancement</li>
+			<li class="mb-1">Keyboard emanations, countermeasures, mesh implications</li>
+		</ul>
+		<div class="flex gap-4 flex-wrap text-sm text-surface-500 mb-3">
+			<span class="bg-surface-700 px-2 py-0.5 rounded">3-hour lab</span>
+			<span class="bg-surface-700 px-2 py-0.5 rounded">HackRF H4M provided</span>
+		</div>
+	</a>
 
-	.level h2 {
-		margin: 0;
-	}
-
-	.level p {
-		color: #555;
-		margin: 0 0 0.75rem;
-	}
-
-	.level ul {
-		color: #555;
-		font-size: 0.9rem;
-		margin: 0 0 1rem;
-		padding-left: 1.5rem;
-	}
-
-	.level li {
-		margin-bottom: 0.25rem;
-	}
-
-	.meta {
-		display: flex;
-		gap: 1rem;
-		flex-wrap: wrap;
-		font-size: 0.85rem;
-		color: #888;
-		margin-bottom: 0.75rem;
-	}
-
-	.meta span {
-		background: #f5f5f5;
-		padding: 0.2rem 0.5rem;
-		border-radius: 3px;
-	}
-
-	.status {
-		display: inline-block;
-		padding: 0.15rem 0.5rem;
-		border-radius: 4px;
-		font-size: 0.8rem;
-		background: #00d4aa;
-		color: white;
-	}
-</style>
+	<a href="{base}/curriculum/tails" class="block p-6 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center gap-4 mb-3">
+			<span class="px-3 py-1 rounded text-sm font-semibold bg-surface-950 text-primary-400 whitespace-nowrap">Privacy</span>
+			<h2 class="text-xl font-bold text-surface-50 m-0">TAILS and Secure Communications</h2>
+		</div>
+		<p class="text-surface-400 mb-3">6-part lab on maximum operational security using TAILS OS with mesh networking.</p>
+		<ul class="text-surface-400 text-sm pl-6 mb-4">
+			<li class="mb-1">TAILS introduction: amnesic system, Tor routing, persistence volumes</li>
+			<li class="mb-1">Mesh + TAILS combination: meshtastic-cli on TAILS, air-gapped workflows</li>
+			<li class="mb-1">Hands-on: boot TAILS from USB, verify signatures, configure persistence</li>
+			<li class="mb-1">5-layer OpSec model: physical, digital, communications, behavioral, network</li>
+			<li class="mb-1">Practical scenarios: journalist protection, protest communications, disaster response</li>
+		</ul>
+		<div class="flex gap-4 flex-wrap text-sm text-surface-500 mb-3">
+			<span class="bg-surface-700 px-2 py-0.5 rounded">3-hour lab</span>
+			<span class="bg-surface-700 px-2 py-0.5 rounded">USB drives provided</span>
+		</div>
+	</a>
+</div>

--- a/site/src/routes/devices/+page.svelte
+++ b/site/src/routes/devices/+page.svelte
@@ -1,116 +1,86 @@
 <script>
 	import { base } from '$app/paths';
+	import StatusBadge from '$lib/components/StatusBadge.svelte';
 </script>
 
 <svelte:head>
 	<title>Devices - LA-Mesh</title>
 </svelte:head>
 
-<h1>Supported Devices</h1>
+<h1 class="text-3xl font-bold text-surface-50 mb-8">Supported Devices</h1>
 
-<div class="devices">
-	<div class="device">
-		<h2>Station G2</h2>
-		<span class="role">Base Station / Relay</span>
-		<p>High-power (up to 4.46W) base station for rooftop and tower deployment. ESP32-S3 + SX1262 with dedicated PA and ultra-low noise LNA.</p>
-		<dl>
-			<dt>Price</dt><dd>~$109</dd>
-			<dt>TX Power</dt><dd>Up to 36.5 dBm</dd>
-			<dt>Firmware</dt><dd>Meshtastic ROUTER mode</dd>
-			<dt>Role</dt><dd>Fixed relay infrastructure</dd>
+<div class="grid gap-8 mt-8">
+	<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+		<div class="flex items-center gap-3 mb-1">
+			<h2 class="text-xl font-bold text-surface-50 m-0">Station G2</h2>
+			<StatusBadge status="working" />
+		</div>
+		<span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-primary-500/20 text-primary-400 mb-3">Base Station / Relay</span>
+		<p class="text-surface-300 mb-4">High-power (up to 4.46W) base station for rooftop and tower deployment. ESP32-S3 + SX1262 with dedicated PA and ultra-low noise LNA.</p>
+		<dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+			<dt class="font-semibold text-surface-400">Price</dt><dd class="text-surface-200 m-0">~$109</dd>
+			<dt class="font-semibold text-surface-400">TX Power</dt><dd class="text-surface-200 m-0">Up to 36.5 dBm</dd>
+			<dt class="font-semibold text-surface-400">Firmware</dt><dd class="text-surface-200 m-0">Meshtastic ROUTER mode</dd>
+			<dt class="font-semibold text-surface-400">Role</dt><dd class="text-surface-200 m-0">Fixed relay infrastructure</dd>
 		</dl>
 	</div>
 
-	<div class="device">
-		<h2>T-Deck Plus</h2>
-		<span class="role">Mobile Client</span>
-		<p>Full-featured portable client with 2.8" IPS LCD, QWERTY keyboard, GPS, and 2000 mAh battery. Best firmware support, M5Stack dual-boot capable.</p>
-		<dl>
-			<dt>Price</dt><dd>$77-82</dd>
-			<dt>TX Power</dt><dd>22 dBm</dd>
-			<dt>Firmware</dt><dd>Meshtastic CLIENT mode</dd>
-			<dt>Role</dt><dd>Community member portable device</dd>
+	<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+		<div class="flex items-center gap-3 mb-1">
+			<h2 class="text-xl font-bold text-surface-50 m-0">T-Deck Plus</h2>
+			<StatusBadge status="working" />
+		</div>
+		<span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-primary-500/20 text-primary-400 mb-3">Mobile Client</span>
+		<p class="text-surface-300 mb-4">Full-featured portable client with 2.8" IPS LCD, QWERTY keyboard, GPS, and 2000 mAh battery. Best firmware support, M5Stack dual-boot capable.</p>
+		<dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+			<dt class="font-semibold text-surface-400">Price</dt><dd class="text-surface-200 m-0">$77-82</dd>
+			<dt class="font-semibold text-surface-400">TX Power</dt><dd class="text-surface-200 m-0">22 dBm</dd>
+			<dt class="font-semibold text-surface-400">Firmware</dt><dd class="text-surface-200 m-0">Meshtastic CLIENT mode</dd>
+			<dt class="font-semibold text-surface-400">Role</dt><dd class="text-surface-200 m-0">Community member portable device</dd>
 		</dl>
 	</div>
 
-	<div class="device">
-		<h2>T-Deck Pro (E-Ink)</h2>
-		<span class="role">Low-Power Client</span>
-		<p>3.1" e-paper touchscreen, sunlight-readable, excellent battery life. Available in Audio and 4G LTE variants.</p>
-		<dl>
-			<dt>Price</dt><dd>$92-111</dd>
-			<dt>TX Power</dt><dd>22 dBm</dd>
-			<dt>Firmware</dt><dd>Meshtastic BaseUI</dd>
-			<dt>Role</dt><dd>Battery-optimized portable</dd>
+	<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+		<div class="flex items-center gap-3 mb-1">
+			<h2 class="text-xl font-bold text-surface-50 m-0">T-Deck Pro (E-Ink)</h2>
+			<StatusBadge status="working" />
+		</div>
+		<span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-primary-500/20 text-primary-400 mb-3">Low-Power Client</span>
+		<p class="text-surface-300 mb-4">3.1" e-paper touchscreen, sunlight-readable, excellent battery life. Available in Audio and 4G LTE variants.</p>
+		<dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+			<dt class="font-semibold text-surface-400">Price</dt><dd class="text-surface-200 m-0">$92-111</dd>
+			<dt class="font-semibold text-surface-400">TX Power</dt><dd class="text-surface-200 m-0">22 dBm</dd>
+			<dt class="font-semibold text-surface-400">Firmware</dt><dd class="text-surface-200 m-0">Meshtastic BaseUI</dd>
+			<dt class="font-semibold text-surface-400">Role</dt><dd class="text-surface-200 m-0">Battery-optimized portable</dd>
 		</dl>
 	</div>
 
-	<div class="device">
-		<h2>MeshAdv-Mini</h2>
-		<span class="role">Pi HAT Gateway</span>
-		<p>Custom PCB Raspberry Pi HAT with SX1262 LoRa, GPS, and I2C. Runs meshtasticd (Linux-native Meshtastic) for bridge/gateway duty.</p>
-		<dl>
-			<dt>Price</dt><dd>~$40 + Pi</dd>
-			<dt>TX Power</dt><dd>22 dBm</dd>
-			<dt>Firmware</dt><dd>meshtasticd (Linux)</dd>
-			<dt>Role</dt><dd>SMS/Email bridge gateway</dd>
+	<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+		<div class="flex items-center gap-3 mb-1">
+			<h2 class="text-xl font-bold text-surface-50 m-0">MeshAdv-Mini</h2>
+			<StatusBadge status="experimental" />
+		</div>
+		<span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-primary-500/20 text-primary-400 mb-3">Pi HAT Gateway</span>
+		<p class="text-surface-300 mb-4">Custom PCB Raspberry Pi HAT with SX1262 LoRa, GPS, and I2C. Runs meshtasticd (Linux-native Meshtastic) for bridge/gateway duty.</p>
+		<dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+			<dt class="font-semibold text-surface-400">Price</dt><dd class="text-surface-200 m-0">~$40 + Pi</dd>
+			<dt class="font-semibold text-surface-400">TX Power</dt><dd class="text-surface-200 m-0">22 dBm</dd>
+			<dt class="font-semibold text-surface-400">Firmware</dt><dd class="text-surface-200 m-0">meshtasticd (Linux)</dd>
+			<dt class="font-semibold text-surface-400">Role</dt><dd class="text-surface-200 m-0">SMS/Email bridge gateway</dd>
 		</dl>
 	</div>
 
-	<div class="device">
-		<h2>HackRF H4M PortaPack</h2>
-		<span class="role">Education Tool</span>
-		<p>Software-defined radio for LoRa spectrum analysis, protocol education, TEMPEST demonstrations, and RF engineering coursework. NOT a mesh participant.</p>
-		<dl>
-			<dt>Price</dt><dd>$200-350</dd>
-			<dt>Firmware</dt><dd>Mayhem</dd>
-			<dt>Role</dt><dd>RF analysis and education only</dd>
+	<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+		<div class="flex items-center gap-3 mb-1">
+			<h2 class="text-xl font-bold text-surface-50 m-0">HackRF H4M PortaPack</h2>
+			<StatusBadge status="working" />
+		</div>
+		<span class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-primary-500/20 text-primary-400 mb-3">Education Tool</span>
+		<p class="text-surface-300 mb-4">Software-defined radio for LoRa spectrum analysis, protocol education, TEMPEST demonstrations, and RF engineering coursework. NOT a mesh participant.</p>
+		<dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm">
+			<dt class="font-semibold text-surface-400">Price</dt><dd class="text-surface-200 m-0">$200-350</dd>
+			<dt class="font-semibold text-surface-400">Firmware</dt><dd class="text-surface-200 m-0">Mayhem</dd>
+			<dt class="font-semibold text-surface-400">Role</dt><dd class="text-surface-200 m-0">RF analysis and education only</dd>
 		</dl>
 	</div>
 </div>
-
-<style>
-	.devices {
-		display: grid;
-		gap: 2rem;
-		margin-top: 2rem;
-	}
-
-	.device {
-		padding: 1.5rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		background: white;
-	}
-
-	.device h2 {
-		margin: 0 0 0.25rem;
-	}
-
-	.role {
-		display: inline-block;
-		background: #00d4aa;
-		color: white;
-		padding: 0.15rem 0.5rem;
-		border-radius: 4px;
-		font-size: 0.8rem;
-		margin-bottom: 0.75rem;
-	}
-
-	dl {
-		display: grid;
-		grid-template-columns: auto 1fr;
-		gap: 0.25rem 1rem;
-		margin: 1rem 0 0;
-		font-size: 0.9rem;
-	}
-
-	dt {
-		font-weight: 600;
-		color: #555;
-	}
-
-	dd {
-		margin: 0;
-	}
-</style>

--- a/site/src/routes/guides/+layout.svelte
+++ b/site/src/routes/guides/+layout.svelte
@@ -1,12 +1,13 @@
 <script>
 	import Giscus from '$lib/components/Giscus.svelte';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 
-	// Only show Giscus on individual guide pages, not the index
-	$: isGuidePage = $page.url.pathname !== '/guides' && $page.url.pathname !== '/guides/';
+	let { children } = $props();
+
+	let isGuidePage = $derived(page.url.pathname !== '/guides' && page.url.pathname !== '/guides/');
 </script>
 
-<slot />
+{@render children()}
 
 {#if isGuidePage}
 	<Giscus />

--- a/site/src/routes/guides/+page.svelte
+++ b/site/src/routes/guides/+page.svelte
@@ -1,131 +1,109 @@
 <script>
 	import { base } from '$app/paths';
+	import StatusBadge from '$lib/components/StatusBadge.svelte';
 </script>
 
 <svelte:head>
 	<title>Guides - LA-Mesh</title>
 </svelte:head>
 
-<h1>Guides</h1>
-<p>Step-by-step instructions for joining and operating on the LA-Mesh network.</p>
+<h1 class="text-3xl font-bold text-surface-50 mb-2">Guides</h1>
+<p class="text-surface-400 mb-8">Step-by-step instructions for joining and operating on the LA-Mesh network.</p>
 
-<div class="guide-list">
-	<a href="{base}/guides/community-onboarding" class="guide">
-		<h2>Community Onboarding</h2>
-		<p>Welcome to LA-Mesh. Get your device, learn the basics, and join the mesh.</p>
-		<span class="status">Start Here</span>
+<div class="grid gap-4">
+	<a href="{base}/guides/community-onboarding" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Community Onboarding</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Welcome to LA-Mesh. Get your device, learn the basics, and join the mesh.</p>
 	</a>
 
-	<a href="{base}/guides/firmware-flashing" class="guide">
-		<h2>Firmware Flashing</h2>
-		<p>Flash Meshtastic or MeshCore firmware via web flasher, CLI, or meshtasticd.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/firmware-flashing" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Firmware Flashing</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Flash Meshtastic or MeshCore firmware via web flasher, CLI, or meshtasticd.</p>
 	</a>
 
-	<a href="{base}/guides/device-profiles" class="guide">
-		<h2>Device Profiles</h2>
-		<p>Choose and apply the right configuration profile for your device role.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/device-profiles" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Device Profiles</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Choose and apply the right configuration profile for your device role.</p>
 	</a>
 
-	<a href="{base}/guides/troubleshooting" class="guide">
-		<h2>Troubleshooting</h2>
-		<p>Common issues and solutions for devices, network, firmware, and bridges.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/troubleshooting" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Troubleshooting</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Common issues and solutions for devices, network, firmware, and bridges.</p>
 	</a>
 
-	<a href="{base}/guides/node-deployment" class="guide">
-		<h2>Node Deployment</h2>
-		<p>Site survey, preparation, installation, verification, and ongoing monitoring for relay nodes.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/node-deployment" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Node Deployment</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Site survey, preparation, installation, verification, and ongoing monitoring for relay nodes.</p>
 	</a>
 
-	<a href="{base}/guides/bench-testing" class="guide">
-		<h2>Bench Testing Protocol</h2>
-		<p>6 structured test protocols: basic comms, indoor/outdoor range, multi-hop, antenna comparison, battery life.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/bench-testing" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Bench Testing Protocol</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">6 structured test protocols: basic comms, indoor/outdoor range, multi-hop, antenna comparison, battery life.</p>
 	</a>
 
-	<a href="{base}/guides/key-management" class="guide">
-		<h2>Key Management</h2>
-		<p>PSK lifecycle, operator roles, key rotation procedures, and credential management.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/key-management" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Key Management</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">PSK lifecycle, operator roles, key rotation procedures, and credential management.</p>
 	</a>
 
-	<a href="{base}/guides/gpg" class="guide">
-		<h2>GPG Quick Start</h2>
-		<p>Ed25519 key generation, signing, encryption, keyserver publishing, and firmware verification.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/gpg" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">GPG Quick Start</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Ed25519 key generation, signing, encryption, keyserver publishing, and firmware verification.</p>
 	</a>
 
-	<a href="{base}/guides/stealth-mode" class="guide">
-		<h2>Stealth Mode</h2>
-		<p>Minimize RF footprint with CLIENT_HIDDEN mode, disable position broadcast, reduce network visibility.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/stealth-mode" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Stealth Mode</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Minimize RF footprint with CLIENT_HIDDEN mode, disable position broadcast, reduce network visibility.</p>
 	</a>
 
-	<a href="{base}/guides/solar-relay" class="guide">
-		<h2>Solar Relay Deployment</h2>
-		<p>Panel sizing for 44.1N latitude, battery calculations, weatherproofing, and seasonal maintenance.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/solar-relay" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Solar Relay Deployment</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Panel sizing for 44.1N latitude, battery calculations, weatherproofing, and seasonal maintenance.</p>
 	</a>
 
-	<a href="{base}/guides/firmware-switching" class="guide">
-		<h2>Firmware Switching</h2>
-		<p>Switch between Meshtastic and MeshCore firmware. Backup, erase, flash, and configure in ~60 seconds.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/firmware-switching" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Firmware Switching</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Switch between Meshtastic and MeshCore firmware. Backup, erase, flash, and configure in ~60 seconds.</p>
 	</a>
 
-	<a href="{base}/guides/developing" class="guide">
-		<h2>Developer Guide</h2>
-		<p>Dev environment setup (Nix or manual), repo structure, just recipes, branch strategy, and CI/CD.</p>
-		<span class="status">Available</span>
+	<a href="{base}/guides/developing" class="block p-5 border border-surface-700 rounded-lg bg-surface-800 no-underline text-inherit hover:border-primary-500 transition-colors">
+		<div class="flex items-center justify-between mb-2">
+			<h2 class="text-lg font-bold text-surface-50 m-0">Developer Guide</h2>
+			<StatusBadge status="working" />
+		</div>
+		<p class="text-surface-400 text-sm m-0">Dev environment setup (Nix or manual), repo structure, just recipes, branch strategy, and CI/CD.</p>
 	</a>
 </div>
-
-<style>
-	p {
-		color: #555;
-		margin-bottom: 2rem;
-	}
-
-	.guide-list {
-		display: grid;
-		gap: 1rem;
-	}
-
-	.guide {
-		display: block;
-		padding: 1.25rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		background: white;
-		text-decoration: none;
-		color: inherit;
-		transition: border-color 0.2s, box-shadow 0.2s;
-	}
-
-	a.guide:hover {
-		border-color: #00d4aa;
-		box-shadow: 0 2px 8px rgba(0, 212, 170, 0.15);
-	}
-
-	.guide h2 {
-		margin: 0 0 0.5rem;
-		font-size: 1.2rem;
-	}
-
-	.guide p {
-		margin: 0 0 0.75rem;
-		color: #555;
-	}
-
-	.status {
-		display: inline-block;
-		padding: 0.15rem 0.5rem;
-		border-radius: 4px;
-		font-size: 0.8rem;
-		background: #00d4aa;
-		color: white;
-	}
-</style>

--- a/site/src/routes/guides/bench-testing/+page.svelte
+++ b/site/src/routes/guides/bench-testing/+page.svelte
@@ -6,75 +6,64 @@
 	<title>Bench Testing - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Bench Testing
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Bench Testing
 </nav>
 
 <h1>Bench Testing Protocol</h1>
-<p class="intro">6 structured test protocols to establish baseline RF performance before field deployment.</p>
+<p class="text-lg text-surface-400 mb-8">6 structured test protocols to establish baseline RF performance before field deployment.</p>
 
-<section>
-	<h2>Equipment Needed</h2>
-	<ul>
-		<li>2+ configured Meshtastic devices (v2.7.15+)</li>
-		<li>USB cables for serial connection</li>
-		<li>Laptop with meshtastic CLI</li>
-		<li>Notebook for recording observations</li>
-		<li>Tape measure or known distances</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Equipment Needed</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">2+ configured Meshtastic devices (v2.7.15+)</li>
+		<li class="mb-1">USB cables for serial connection</li>
+		<li class="mb-1">Laptop with meshtastic CLI</li>
+		<li class="mb-1">Notebook for recording observations</li>
+		<li class="mb-1">Tape measure or known distances</li>
 	</ul>
 </section>
 
-<section>
-	<h2>Test 1: Basic Communication (Indoor)</h2>
-	<p>Verify two devices can exchange messages at close range.</p>
-	<pre class="code">{`# On device A
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Test 1: Basic Communication (Indoor)</h2>
+	<p class="text-surface-300 mb-4">Verify two devices can exchange messages at close range.</p>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# On device A
 meshtastic --port /dev/ttyUSB0 --sendtext "TEST-1-$(date +%s)"
 
 # On device B -- verify message received
 meshtastic --port /dev/ttyACM0 --info`}</pre>
-	<table>
-		<thead><tr><th>Metric</th><th>Expected</th></tr></thead>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Metric</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Expected</th></tr></thead>
 		<tbody>
-			<tr><td>Delivery</td><td>100% at &lt;5m indoor</td></tr>
-			<tr><td>Latency</td><td>&lt;5 seconds</td></tr>
-			<tr><td>SNR</td><td>&gt;10 dB</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Delivery</td><td class="p-3 text-surface-200 border-b border-surface-700">100% at &lt;5m indoor</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Latency</td><td class="p-3 text-surface-200 border-b border-surface-700">&lt;5 seconds</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">SNR</td><td class="p-3 text-surface-200 border-b border-surface-700">&gt;10 dB</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Test 2: Indoor Range</h2>
-	<p>Walk devices to opposite ends of building. Record SNR/RSSI at each distance.</p>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Test 2: Indoor Range</h2>
+	<p class="text-surface-300 mb-4">Walk devices to opposite ends of building. Record SNR/RSSI at each distance.</p>
 </section>
 
-<section>
-	<h2>Test 3: Outdoor Range</h2>
-	<p>Open field test. Walk apart in 100m increments, recording SNR/RSSI. Note first packet loss distance.</p>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Test 3: Outdoor Range</h2>
+	<p class="text-surface-300 mb-4">Open field test. Walk apart in 100m increments, recording SNR/RSSI. Note first packet loss distance.</p>
 </section>
 
-<section>
-	<h2>Test 4: Multi-Hop</h2>
-	<p>Place 3+ devices in a line. Verify messages hop through intermediate nodes.</p>
-	<pre class="code">{`meshtastic --traceroute '!<node-id>'`}</pre>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Test 4: Multi-Hop</h2>
+	<p class="text-surface-300 mb-4">Place 3+ devices in a line. Verify messages hop through intermediate nodes.</p>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`meshtastic --traceroute '!<node-id>'`}</pre>
 </section>
 
-<section>
-	<h2>Test 5: Antenna Comparison</h2>
-	<p>Swap antennas on same device at same location. Record SNR/RSSI for stock vs upgraded antenna.</p>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Test 5: Antenna Comparison</h2>
+	<p class="text-surface-300 mb-4">Swap antennas on same device at same location. Record SNR/RSSI for stock vs upgraded antenna.</p>
 </section>
 
-<section>
-	<h2>Test 6: Battery Life</h2>
-	<p>Fully charge device, enable periodic telemetry, record time until shutdown. Document device role and screen settings.</p>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Test 6: Battery Life</h2>
+	<p class="text-surface-300 mb-4">Fully charge device, enable periodic telemetry, record time until shutdown. Document device role and screen settings.</p>
 </section>
-
-<style>
-	.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1rem; }
-	.breadcrumb a { color: #00d4aa; text-decoration: none; }
-	.intro { font-size: 1.1rem; color: #555; margin-bottom: 2rem; }
-	section { margin-bottom: 3rem; }
-	.code { background: #1a1a2e; color: #00d4aa; padding: 1.25rem; border-radius: 8px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
-	table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-	th, td { padding: 0.75rem; border: 1px solid #ddd; text-align: left; }
-	th { background: #f5f5f5; font-weight: 600; }
-</style>

--- a/site/src/routes/guides/community-onboarding/+page.svelte
+++ b/site/src/routes/guides/community-onboarding/+page.svelte
@@ -6,305 +6,154 @@
 	<title>Community Onboarding - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Community Onboarding
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Community Onboarding
 </nav>
 
 <h1>Community Onboarding Guide</h1>
-<p class="intro">Welcome to LA-Mesh! This guide walks you through joining the community mesh network in the Lewiston-Auburn area.</p>
+<p class="text-lg text-surface-400 mb-8">Welcome to LA-Mesh! This guide walks you through joining the community mesh network in the Lewiston-Auburn area.</p>
 
-<section>
-	<h2>What You Need</h2>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">What You Need</h2>
 
-	<div class="options">
-		<div class="option recommended">
-			<h3>Option A: Dedicated Device (Recommended)</h3>
-			<p>Purchase a T-Deck Plus (~$82) or T-Deck Pro e-ink (~$111). These are standalone mesh radios with keyboards and screens -- no phone needed.</p>
+	<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+		<div class="p-5 border border-primary-500 border-2 rounded-lg bg-surface-800">
+			<h3 class="mt-0 text-surface-100">Option A: Dedicated Device (Recommended)</h3>
+			<p class="text-surface-300 mb-4">Purchase a T-Deck Plus (~$82) or T-Deck Pro e-ink (~$111). These are standalone mesh radios with keyboards and screens -- no phone needed.</p>
 		</div>
 
-		<div class="option">
-			<h3>Option B: Phone + Bluetooth Device</h3>
-			<p>Any Meshtastic-compatible device (~$25-80) paired with the Meshtastic app on your phone:</p>
-			<ul>
-				<li><strong>Android</strong>: Meshtastic app on Google Play</li>
-				<li><strong>iOS</strong>: Meshtastic app on App Store</li>
+		<div class="p-5 border border-surface-700 rounded-lg bg-surface-800">
+			<h3 class="mt-0 text-surface-100">Option B: Phone + Bluetooth Device</h3>
+			<p class="text-surface-300 mb-4">Any Meshtastic-compatible device (~$25-80) paired with the Meshtastic app on your phone:</p>
+			<ul class="text-surface-300 pl-6 mb-4">
+				<li class="mb-1"><strong>Android</strong>: Meshtastic app on Google Play</li>
+				<li class="mb-1"><strong>iOS</strong>: Meshtastic app on App Store</li>
 			</ul>
 		</div>
 	</div>
 </section>
 
-<section>
-	<h2>Getting Connected</h2>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Getting Connected</h2>
 
-	<div class="steps">
-		<div class="step">
-			<span class="step-num">1</span>
+	<div class="grid gap-6">
+		<div class="flex gap-5 p-5 border border-surface-700 rounded-lg bg-surface-800">
+			<span class="flex items-center justify-center w-10 h-10 min-w-[40px] bg-surface-900 text-primary-400 rounded-full font-bold text-xl">1</span>
 			<div>
-				<h3>Get Your Device Configured</h3>
-				<p>Attend a community meetup where an LA-Mesh operator will provision your device:</p>
-				<pre class="code">{`just provision t-deck /dev/ttyUSB0`}</pre>
-				<p>This single command fetches the manifest-pinned firmware (v2.7.15+), verifies its SHA256 checksum, flashes it, applies the device profile, and configures LA-Mesh channels with the shared PSK.</p>
-				<p class="note"><strong>Why in-person?</strong> The encryption key (PSK) is only shared face-to-face for security. We never send it digitally. The <code>just provision</code> command reads the PSK from the operator's local environment.</p>
+				<h3 class="mt-0 text-surface-100">Get Your Device Configured</h3>
+				<p class="text-surface-300 mb-4">Attend a community meetup where an LA-Mesh operator will provision your device:</p>
+				<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`just provision t-deck /dev/ttyUSB0`}</pre>
+				<p class="text-surface-300 mb-4">This single command fetches the manifest-pinned firmware (v2.7.15+), verifies its SHA256 checksum, flashes it, applies the device profile, and configures LA-Mesh channels with the shared PSK.</p>
+				<p class="text-sm text-surface-400 italic"><strong>Why in-person?</strong> The encryption key (PSK) is only shared face-to-face for security. We never send it digitally. The <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just provision</code> command reads the PSK from the operator's local environment.</p>
 			</div>
 		</div>
 
-		<div class="step">
-			<span class="step-num">2</span>
+		<div class="flex gap-5 p-5 border border-surface-700 rounded-lg bg-surface-800">
+			<span class="flex items-center justify-center w-10 h-10 min-w-[40px] bg-surface-900 text-primary-400 rounded-full font-bold text-xl">2</span>
 			<div>
-				<h3>Learn the Basics</h3>
-				<p>At the meetup, you'll learn:</p>
-				<ul>
-					<li>How to send and receive messages</li>
-					<li>How to read the node list</li>
-					<li>What the signal quality numbers mean</li>
-					<li>Basic mesh etiquette</li>
+				<h3 class="mt-0 text-surface-100">Learn the Basics</h3>
+				<p class="text-surface-300 mb-4">At the meetup, you'll learn:</p>
+				<ul class="text-surface-300 pl-6 mb-4">
+					<li class="mb-1">How to send and receive messages</li>
+					<li class="mb-1">How to read the node list</li>
+					<li class="mb-1">What the signal quality numbers mean</li>
+					<li class="mb-1">Basic mesh etiquette</li>
 				</ul>
 			</div>
 		</div>
 
-		<div class="step">
-			<span class="step-num">3</span>
+		<div class="flex gap-5 p-5 border border-surface-700 rounded-lg bg-surface-800">
+			<span class="flex items-center justify-center w-10 h-10 min-w-[40px] bg-surface-900 text-primary-400 rounded-full font-bold text-xl">3</span>
 			<div>
-				<h3>Stay Connected</h3>
-				<ul>
-					<li>Keep your device charged and powered on when in the L-A area</li>
-					<li>Your device automatically relays messages for other users</li>
-					<li>Check for firmware updates at community meetups</li>
+				<h3 class="mt-0 text-surface-100">Stay Connected</h3>
+				<ul class="text-surface-300 pl-6 mb-4">
+					<li class="mb-1">Keep your device charged and powered on when in the L-A area</li>
+					<li class="mb-1">Your device automatically relays messages for other users</li>
+					<li class="mb-1">Check for firmware updates at community meetups</li>
 				</ul>
 			</div>
 		</div>
 	</div>
 </section>
 
-<section>
-	<h2>Mesh Etiquette</h2>
-	<ol class="etiquette">
-		<li><strong>Keep messages concise</strong> -- LoRa is low bandwidth (~1 text message per second)</li>
-		<li><strong>Don't spam</strong> -- excessive messages use airtime that everyone shares</li>
-		<li><strong>Emergency channel is for emergencies only</strong> -- false alarms erode trust</li>
-		<li><strong>Report issues</strong> -- coverage gaps, connectivity problems, suspicious activity</li>
-		<li><strong>Attend meetups</strong> -- for PSK rotations and firmware updates</li>
-		<li><strong>Share knowledge</strong> -- help newcomers get set up</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Mesh Etiquette</h2>
+	<ol class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1"><strong>Keep messages concise</strong> -- LoRa is low bandwidth (~1 text message per second)</li>
+		<li class="mb-1"><strong>Don't spam</strong> -- excessive messages use airtime that everyone shares</li>
+		<li class="mb-1"><strong>Emergency channel is for emergencies only</strong> -- false alarms erode trust</li>
+		<li class="mb-1"><strong>Report issues</strong> -- coverage gaps, connectivity problems, suspicious activity</li>
+		<li class="mb-1"><strong>Attend meetups</strong> -- for PSK rotations and firmware updates</li>
+		<li class="mb-1"><strong>Share knowledge</strong> -- help newcomers get set up</li>
 	</ol>
 </section>
 
-<section>
-	<h2>Frequently Asked Questions</h2>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Frequently Asked Questions</h2>
 
-	<div class="faq-list">
-		<details>
-			<summary>Can people read my messages?</summary>
-			<p>Channel messages are encrypted (AES-256) -- only LA-Mesh members with the PSK can read them. For private conversations, use Direct Messages, which have additional end-to-end encryption that even other LA-Mesh members can't read.</p>
+	<div class="grid gap-2">
+		<details class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<summary class="cursor-pointer font-semibold text-surface-100">Can people read my messages?</summary>
+			<p class="text-surface-400 mt-3 m-0">Channel messages are encrypted (AES-256) -- only LA-Mesh members with the PSK can read them. For private conversations, use Direct Messages, which have additional end-to-end encryption that even other LA-Mesh members can't read.</p>
 		</details>
 
-		<details>
-			<summary>How far does the signal reach?</summary>
-			<p>Typically 1-5 km in urban areas, up to 20+ km with line-of-sight to a router. Your messages can "hop" through other devices to reach further.</p>
+		<details class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<summary class="cursor-pointer font-semibold text-surface-100">How far does the signal reach?</summary>
+			<p class="text-surface-400 mt-3 m-0">Typically 1-5 km in urban areas, up to 20+ km with line-of-sight to a router. Your messages can "hop" through other devices to reach further.</p>
 		</details>
 
-		<details>
-			<summary>Does it use the internet?</summary>
-			<p>No! The mesh operates entirely on LoRa radio. No WiFi, no cell service, no internet needed. The gateway bridge provides optional SMS/email connectivity.</p>
+		<details class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<summary class="cursor-pointer font-semibold text-surface-100">Does it use the internet?</summary>
+			<p class="text-surface-400 mt-3 m-0">No! The mesh operates entirely on LoRa radio. No WiFi, no cell service, no internet needed. The gateway bridge provides optional SMS/email connectivity.</p>
 		</details>
 
-		<details>
-			<summary>Can I see my location on the network?</summary>
-			<p>If GPS is enabled, your position is shared with other mesh users. You can disable GPS in your device settings if you prefer not to share location.</p>
+		<details class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<summary class="cursor-pointer font-semibold text-surface-100">Can I see my location on the network?</summary>
+			<p class="text-surface-400 mt-3 m-0">If GPS is enabled, your position is shared with other mesh users. You can disable GPS in your device settings if you prefer not to share location.</p>
 		</details>
 
-		<details>
-			<summary>What happens if a tower node goes down?</summary>
-			<p>The mesh re-routes around it. With multiple routers, the network is resilient to individual node failures.</p>
+		<details class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<summary class="cursor-pointer font-semibold text-surface-100">What happens if a tower node goes down?</summary>
+			<p class="text-surface-400 mt-3 m-0">The mesh re-routes around it. With multiple routers, the network is resilient to individual node failures.</p>
 		</details>
 
-		<details>
-			<summary>Can I use this for voice calls?</summary>
-			<p>No. LoRa is text-only due to low bandwidth. Think of it like texting, not calling.</p>
+		<details class="p-4 border border-surface-700 rounded-lg bg-surface-800">
+			<summary class="cursor-pointer font-semibold text-surface-100">Can I use this for voice calls?</summary>
+			<p class="text-surface-400 mt-3 m-0">No. LoRa is text-only due to low bandwidth. Think of it like texting, not calling.</p>
 		</details>
 	</div>
 </section>
 
-<section>
-	<h2>Community Meetups</h2>
-	<div class="meetup-info">
-		<div class="config-item">
-			<span class="label">Location</span>
-			<span class="value">TBD (Lewiston-Auburn area)</span>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Community Meetups</h2>
+	<div class="grid gap-2">
+		<div class="flex justify-between p-3 bg-surface-800 rounded-md border-l-[3px] border-primary-400">
+			<span class="font-semibold text-surface-400">Location</span>
+			<span class="text-surface-200">TBD (Lewiston-Auburn area)</span>
 		</div>
-		<div class="config-item">
-			<span class="label">Frequency</span>
-			<span class="value">Monthly (more often during setup phase)</span>
+		<div class="flex justify-between p-3 bg-surface-800 rounded-md border-l-[3px] border-primary-400">
+			<span class="font-semibold text-surface-400">Frequency</span>
+			<span class="text-surface-200">Monthly (more often during setup phase)</span>
 		</div>
-		<div class="config-item">
-			<span class="label">Purpose</span>
-			<span class="value">Onboarding, PSK rotation, firmware updates, coverage reports</span>
+		<div class="flex justify-between p-3 bg-surface-800 rounded-md border-l-[3px] border-primary-400">
+			<span class="font-semibold text-surface-400">Purpose</span>
+			<span class="text-surface-200">Onboarding, PSK rotation, firmware updates, coverage reports</span>
 		</div>
 	</div>
 </section>
 
-<section>
-	<h2>Recommended Resources</h2>
-	<ul>
-		<li><a href="https://gajim.org/">Gajim</a> -- open-source XMPP client with OMEMO encryption for operator coordination</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Recommended Resources</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1"><a href="https://gajim.org/" class="text-primary-400">Gajim</a> -- open-source XMPP client with OMEMO encryption for operator coordination</li>
 	</ul>
 </section>
 
-<section>
-	<h2>Want to Help?</h2>
-	<ul>
-		<li><strong>Host a node</strong>: If you have a high location (rooftop, hilltop), we may be able to place a relay node</li>
-		<li><strong>Volunteer</strong>: Help at meetups, assist with installations, contribute to documentation</li>
-		<li><strong>Spread the word</strong>: Tell neighbors, friends, community organizations</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Want to Help?</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1"><strong>Host a node</strong>: If you have a high location (rooftop, hilltop), we may be able to place a relay node</li>
+		<li class="mb-1"><strong>Volunteer</strong>: Help at meetups, assist with installations, contribute to documentation</li>
+		<li class="mb-1"><strong>Spread the word</strong>: Tell neighbors, friends, community organizations</li>
 	</ul>
 </section>
-
-<style>
-	.breadcrumb {
-		font-size: 0.85rem;
-		color: #888;
-		margin-bottom: 1rem;
-	}
-
-	.breadcrumb a {
-		color: #00d4aa;
-		text-decoration: none;
-	}
-
-	.intro {
-		font-size: 1.1rem;
-		color: #555;
-		margin-bottom: 2rem;
-	}
-
-	section {
-		margin-bottom: 3rem;
-	}
-
-	.options {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-		gap: 1rem;
-	}
-
-	.option {
-		padding: 1.25rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		background: white;
-	}
-
-	.option.recommended {
-		border-color: #00d4aa;
-		border-width: 2px;
-	}
-
-	.option h3 {
-		margin-top: 0;
-	}
-
-	.steps {
-		display: grid;
-		gap: 1.5rem;
-	}
-
-	.step {
-		display: flex;
-		gap: 1.25rem;
-		padding: 1.25rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		background: white;
-	}
-
-	.step-num {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 40px;
-		height: 40px;
-		min-width: 40px;
-		background: #1a1a2e;
-		color: #00d4aa;
-		border-radius: 50%;
-		font-weight: bold;
-		font-size: 1.2rem;
-	}
-
-	.step h3 {
-		margin-top: 0;
-	}
-
-	.note {
-		font-size: 0.9rem;
-		color: #888;
-		font-style: italic;
-	}
-
-	.code {
-		background: #1a1a2e;
-		color: #00d4aa;
-		padding: 1rem;
-		border-radius: 8px;
-		overflow-x: auto;
-		font-size: 0.85rem;
-		line-height: 1.5;
-		margin: 0.75rem 0;
-	}
-
-	code {
-		background: #f0f0f0;
-		padding: 0.15rem 0.35rem;
-		border-radius: 3px;
-		font-size: 0.85rem;
-	}
-
-	.etiquette li {
-		margin-bottom: 0.5rem;
-	}
-
-	.faq-list {
-		display: grid;
-		gap: 0.5rem;
-	}
-
-	details {
-		padding: 1rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		background: white;
-	}
-
-	summary {
-		cursor: pointer;
-		font-weight: 600;
-		color: #1a1a2e;
-	}
-
-	details p {
-		margin: 0.75rem 0 0;
-		color: #555;
-	}
-
-	.meetup-info {
-		display: grid;
-		gap: 0.5rem;
-	}
-
-	.config-item {
-		display: flex;
-		justify-content: space-between;
-		padding: 0.75rem 1rem;
-		background: #f9f9f9;
-		border-radius: 6px;
-		border-left: 3px solid #00d4aa;
-	}
-
-	.label {
-		font-weight: 600;
-		color: #555;
-	}
-
-	.value {
-		color: #1a1a2e;
-	}
-</style>

--- a/site/src/routes/guides/developing/+page.svelte
+++ b/site/src/routes/guides/developing/+page.svelte
@@ -6,26 +6,26 @@
 	<title>Developer Guide - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Developer Guide
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Developer Guide
 </nav>
 
 <h1>Developer Guide</h1>
-<p class="intro">Set up the LA-Mesh development environment, build the site, flash devices, and contribute.</p>
+<p class="text-lg text-surface-400 mb-8">Set up the LA-Mesh development environment, build the site, flash devices, and contribute.</p>
 
-<section>
-	<h2>Quick Start (Nix + direnv)</h2>
-	<pre class="code">{`git clone https://github.com/Jesssullivan/LA-Mesh.git
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Quick Start (Nix + direnv)</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`git clone https://github.com/Jesssullivan/LA-Mesh.git
 cd LA-Mesh
 direnv allow        # auto-enters Nix dev shell on cd
 just info           # verify all tools are available`}</pre>
-	<p>The Nix dev shell provides: meshtastic CLI, esptool.py, hackrf tools, bazelisk, just, nodejs, pnpm, git-cliff, shellcheck, ruff.</p>
-	<p>Without Nix: <code>pip install meshtastic esptool ruff</code>, <code>npm install -g pnpm</code>, <code>cargo install just git-cliff</code>.</p>
+	<p class="text-surface-300 mb-4">The Nix dev shell provides: meshtastic CLI, esptool.py, hackrf tools, bazelisk, just, nodejs, pnpm, git-cliff, shellcheck, ruff.</p>
+	<p class="text-surface-300 mb-4">Without Nix: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">pip install meshtastic esptool ruff</code>, <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">npm install -g pnpm</code>, <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">cargo install just git-cliff</code>.</p>
 </section>
 
-<section>
-	<h2>Repository Structure</h2>
-	<pre class="code">{`LA-Mesh/
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Repository Structure</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`LA-Mesh/
 ├── site/              # SvelteKit documentation site
 ├── docs/              # Markdown documentation
 ├── configs/           # Device profiles and channel templates
@@ -37,83 +37,71 @@ just info           # verify all tools are available`}</pre>
 └── captures/          # SDR capture storage (gitignored)`}</pre>
 </section>
 
-<section>
-	<h2>Common Just Recipes</h2>
-	<table>
-		<thead><tr><th>Command</th><th>Purpose</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Common Just Recipes</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Command</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Purpose</th></tr></thead>
 		<tbody>
-			<tr><td><code>just dev</code></td><td>Start docs site dev server (hot reload)</td></tr>
-			<tr><td><code>just build</code></td><td>Build site for production</td></tr>
-			<tr><td><code>just check</code></td><td>Run all validations (format + type check)</td></tr>
-			<tr><td><code>just ci</code></td><td>Full CI simulation (check + build)</td></tr>
-			<tr><td><code>just provision &lt;device&gt; &lt;port&gt;</code></td><td>One-command device provisioning</td></tr>
-			<tr><td><code>just fetch-firmware</code></td><td>Download and verify firmware</td></tr>
-			<tr><td><code>just firmware-versions</code></td><td>Show pinned firmware versions</td></tr>
-			<tr><td><code>just firmware-check</code></td><td>Check for upstream updates</td></tr>
-			<tr><td><code>just mesh-info</code></td><td>Show connected device info</td></tr>
-			<tr><td><code>just mesh-nodes</code></td><td>List visible mesh nodes</td></tr>
-			<tr><td><code>just configure-profile &lt;profile&gt;</code></td><td>Apply device configuration profile</td></tr>
-			<tr><td><code>just configure-channels</code></td><td>Apply LA-Mesh channel config</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just dev</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Start docs site dev server (hot reload)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just build</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Build site for production</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just check</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Run all validations (format + type check)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just ci</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Full CI simulation (check + build)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just provision &lt;device&gt; &lt;port&gt;</code></td><td class="p-3 text-surface-200 border-b border-surface-700">One-command device provisioning</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just fetch-firmware</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Download and verify firmware</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just firmware-versions</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Show pinned firmware versions</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just firmware-check</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Check for upstream updates</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just mesh-info</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Show connected device info</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just mesh-nodes</code></td><td class="p-3 text-surface-200 border-b border-surface-700">List visible mesh nodes</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just configure-profile &lt;profile&gt;</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Apply device configuration profile</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just configure-channels</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Apply LA-Mesh channel config</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Branch Strategy</h2>
-	<table>
-		<thead><tr><th>Branch</th><th>Purpose</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Branch Strategy</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Branch</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Purpose</th></tr></thead>
 		<tbody>
-			<tr><td><code>main</code></td><td>Production -- deploys to GitHub Pages</td></tr>
-			<tr><td><code>feature/*</code></td><td>Feature development</td></tr>
-			<tr><td><code>fix/*</code></td><td>Bug fixes</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">main</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Production -- deploys to GitHub Pages</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">feature/*</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Feature development</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">fix/*</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Bug fixes</td></tr>
 		</tbody>
 	</table>
-	<p>PRs target <code>main</code>. CI must pass before merge.</p>
+	<p class="text-surface-300 mb-4">PRs target <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">main</code>. CI must pass before merge.</p>
 </section>
 
-<section>
-	<h2>CI/CD Workflows</h2>
-	<table>
-		<thead><tr><th>Workflow</th><th>Trigger</th><th>Purpose</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">CI/CD Workflows</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Workflow</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Trigger</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Purpose</th></tr></thead>
 		<tbody>
-			<tr><td><code>ci.yml</code></td><td>Push/PR to main</td><td>Lint, validate, build site</td></tr>
-			<tr><td><code>deploy-pages.yml</code></td><td>Push to main</td><td>Deploy GitHub Pages</td></tr>
-			<tr><td><code>firmware-check.yml</code></td><td>Weekly cron</td><td>Check for firmware updates</td></tr>
-			<tr><td><code>security-scan.yml</code></td><td>Push/PR to main</td><td>Gitleaks, ShellCheck, YAML lint</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">ci.yml</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Push/PR to main</td><td class="p-3 text-surface-200 border-b border-surface-700">Lint, validate, build site</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">deploy-pages.yml</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Push to main</td><td class="p-3 text-surface-200 border-b border-surface-700">Deploy GitHub Pages</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">firmware-check.yml</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Weekly cron</td><td class="p-3 text-surface-200 border-b border-surface-700">Check for firmware updates</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">security-scan.yml</code></td><td class="p-3 text-surface-200 border-b border-surface-700">Push/PR to main</td><td class="p-3 text-surface-200 border-b border-surface-700">Gitleaks, ShellCheck, YAML lint</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Security: Never Commit</h2>
-	<ul>
-		<li>Secrets (never committed -- use encrypted storage)</li>
-		<li>PSK values (channel encryption keys)</li>
-		<li>API keys (SMS gateway, SMTP, MQTT credentials)</li>
-		<li>Private keys (SSH, GPG, TLS)</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Security: Never Commit</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Secrets (never committed -- use encrypted storage)</li>
+		<li class="mb-1">PSK values (channel encryption keys)</li>
+		<li class="mb-1">API keys (SMS gateway, SMTP, MQTT credentials)</li>
+		<li class="mb-1">Private keys (SSH, GPG, TLS)</li>
 	</ul>
-	<p>Enable the pre-commit hook: <code>git config core.hooksPath .githooks</code></p>
+	<p class="text-surface-300 mb-4">Enable the pre-commit hook: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">git config core.hooksPath .githooks</code></p>
 </section>
 
-<section>
-	<h2>Recommended Operating Systems</h2>
-	<table>
-		<thead><tr><th>OS</th><th>Use Case</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Recommended Operating Systems</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">OS</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Use Case</th></tr></thead>
 		<tbody>
-			<tr><td><a href="https://linuxmint.com">Linux Mint</a></td><td>Desktop OS for mesh operators -- stable, beginner-friendly, full hardware support</td></tr>
-			<tr><td><a href="https://rockylinux.org">Rocky Linux</a></td><td>Server OS for gateway and bridge nodes -- enterprise-grade, long-term support</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><a href="https://linuxmint.com" class="text-primary-400">Linux Mint</a></td><td class="p-3 text-surface-200 border-b border-surface-700">Desktop OS for mesh operators -- stable, beginner-friendly, full hardware support</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><a href="https://rockylinux.org" class="text-primary-400">Rocky Linux</a></td><td class="p-3 text-surface-200 border-b border-surface-700">Server OS for gateway and bridge nodes -- enterprise-grade, long-term support</td></tr>
 		</tbody>
 	</table>
 </section>
-
-<style>
-	.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1rem; }
-	.breadcrumb a { color: #00d4aa; text-decoration: none; }
-	.intro { font-size: 1.1rem; color: #555; margin-bottom: 2rem; }
-	section { margin-bottom: 3rem; }
-	.code { background: #1a1a2e; color: #00d4aa; padding: 1.25rem; border-radius: 8px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
-	table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-	th, td { padding: 0.75rem; border: 1px solid #ddd; text-align: left; }
-	th { background: #f5f5f5; font-weight: 600; }
-	a { color: #00d4aa; }
-</style>

--- a/site/src/routes/guides/device-profiles/+page.svelte
+++ b/site/src/routes/guides/device-profiles/+page.svelte
@@ -6,120 +6,120 @@
 	<title>Device Profiles - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Device Profiles
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Device Profiles
 </nav>
 
 <h1>Device Profiles</h1>
-<p class="intro">LA-Mesh uses pre-configured YAML profiles optimized for each device role. Profiles set radio parameters, power management, GPS intervals, and network behavior.</p>
+<p class="text-lg text-surface-400 mb-8">LA-Mesh uses pre-configured YAML profiles optimized for each device role. Profiles set radio parameters, power management, GPS intervals, and network behavior.</p>
 
-<section>
-	<h2>Which Profile Do I Need?</h2>
-	<div class="flowchart">
-		<div class="flow-step">Is this a fixed relay on a rooftop or tower?</div>
-		<div class="flow-arrow">Yes</div>
-		<div class="flow-result">station-g2-router</div>
-		<div class="flow-arrow">No</div>
-		<div class="flow-step">Is this a gateway with internet access?</div>
-		<div class="flow-arrow">Yes</div>
-		<div class="flow-result">meshadv-mini-gateway</div>
-		<div class="flow-arrow">No</div>
-		<div class="flow-step">Is this a T-Deck Pro (e-ink screen)?</div>
-		<div class="flow-arrow">Yes</div>
-		<div class="flow-result">tdeck-pro-eink-client</div>
-		<div class="flow-arrow">No</div>
-		<div class="flow-result">tdeck-plus-client</div>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Which Profile Do I Need?</h2>
+	<div class="flex flex-wrap items-center gap-2 p-6 bg-surface-800 rounded-lg">
+		<div class="bg-surface-700 border border-surface-600 px-4 py-2 rounded-md font-medium text-surface-200">Is this a fixed relay on a rooftop or tower?</div>
+		<div class="text-primary-400 font-bold text-sm">Yes</div>
+		<div class="bg-surface-900 text-primary-400 px-4 py-2 rounded-md font-mono">station-g2-router</div>
+		<div class="text-primary-400 font-bold text-sm">No</div>
+		<div class="bg-surface-700 border border-surface-600 px-4 py-2 rounded-md font-medium text-surface-200">Is this a gateway with internet access?</div>
+		<div class="text-primary-400 font-bold text-sm">Yes</div>
+		<div class="bg-surface-900 text-primary-400 px-4 py-2 rounded-md font-mono">meshadv-mini-gateway</div>
+		<div class="text-primary-400 font-bold text-sm">No</div>
+		<div class="bg-surface-700 border border-surface-600 px-4 py-2 rounded-md font-medium text-surface-200">Is this a T-Deck Pro (e-ink screen)?</div>
+		<div class="text-primary-400 font-bold text-sm">Yes</div>
+		<div class="bg-surface-900 text-primary-400 px-4 py-2 rounded-md font-mono">tdeck-pro-eink-client</div>
+		<div class="text-primary-400 font-bold text-sm">No</div>
+		<div class="bg-surface-900 text-primary-400 px-4 py-2 rounded-md font-mono">tdeck-plus-client</div>
 	</div>
 </section>
 
-<section>
-	<h2>Profile Details</h2>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Profile Details</h2>
 
-	<div class="profiles">
-		<div class="profile">
-			<div class="profile-header">
-				<h3>station-g2-router</h3>
-				<span class="role-badge router">ROUTER</span>
+	<div class="grid gap-6">
+		<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+			<div class="flex items-center gap-4 mb-3">
+				<h3 class="m-0 font-mono text-surface-100">station-g2-router</h3>
+				<span class="px-2 py-0.5 rounded text-xs font-semibold text-white bg-red-500">ROUTER</span>
 			</div>
-			<p>High-power relay for rooftop and tower deployment. Always-on, no power saving.</p>
-			<table>
+			<p class="text-surface-400 m-0 mb-4">High-power relay for rooftop and tower deployment. Always-on, no power saving.</p>
+			<table class="w-full border-collapse mt-4">
 				<tbody>
-					<tr><td>Device Role</td><td>ROUTER</td></tr>
-					<tr><td>TX Power</td><td>30 dBm (1 W)</td></tr>
-					<tr><td>Modem Preset</td><td>LONG_FAST</td></tr>
-					<tr><td>Hop Limit</td><td>5</td></tr>
-					<tr><td>Position Broadcast</td><td>Every 15 min (fixed position)</td></tr>
-					<tr><td>Bluetooth</td><td>Disabled</td></tr>
-					<tr><td>WiFi</td><td>Disabled</td></tr>
-					<tr><td>Power Saving</td><td>Disabled (never sleeps)</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Device Role</td><td class="p-3 text-surface-200 border-b border-surface-700">ROUTER</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">TX Power</td><td class="p-3 text-surface-200 border-b border-surface-700">30 dBm (1 W)</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Modem Preset</td><td class="p-3 text-surface-200 border-b border-surface-700">LONG_FAST</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Hop Limit</td><td class="p-3 text-surface-200 border-b border-surface-700">5</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Position Broadcast</td><td class="p-3 text-surface-200 border-b border-surface-700">Every 15 min (fixed position)</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Bluetooth</td><td class="p-3 text-surface-200 border-b border-surface-700">Disabled</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">WiFi</td><td class="p-3 text-surface-200 border-b border-surface-700">Disabled</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Power Saving</td><td class="p-3 text-surface-200 border-b border-surface-700">Disabled (never sleeps)</td></tr>
 				</tbody>
 			</table>
 		</div>
 
-		<div class="profile">
-			<div class="profile-header">
-				<h3>tdeck-plus-client</h3>
-				<span class="role-badge client">CLIENT</span>
+		<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+			<div class="flex items-center gap-4 mb-3">
+				<h3 class="m-0 font-mono text-surface-100">tdeck-plus-client</h3>
+				<span class="px-2 py-0.5 rounded text-xs font-semibold text-white bg-primary-500">CLIENT</span>
 			</div>
-			<p>Portable device for community members. Balanced power and connectivity.</p>
-			<table>
+			<p class="text-surface-400 m-0 mb-4">Portable device for community members. Balanced power and connectivity.</p>
+			<table class="w-full border-collapse mt-4">
 				<tbody>
-					<tr><td>Device Role</td><td>CLIENT</td></tr>
-					<tr><td>TX Power</td><td>22 dBm</td></tr>
-					<tr><td>Modem Preset</td><td>LONG_FAST</td></tr>
-					<tr><td>Hop Limit</td><td>5</td></tr>
-					<tr><td>GPS Interval</td><td>Every 2 min</td></tr>
-					<tr><td>Position Broadcast</td><td>Every 15 min</td></tr>
-					<tr><td>Bluetooth</td><td>Enabled (for phone app)</td></tr>
-					<tr><td>Power Saving</td><td>Light sleep when idle</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Device Role</td><td class="p-3 text-surface-200 border-b border-surface-700">CLIENT</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">TX Power</td><td class="p-3 text-surface-200 border-b border-surface-700">22 dBm</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Modem Preset</td><td class="p-3 text-surface-200 border-b border-surface-700">LONG_FAST</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Hop Limit</td><td class="p-3 text-surface-200 border-b border-surface-700">5</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">GPS Interval</td><td class="p-3 text-surface-200 border-b border-surface-700">Every 2 min</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Position Broadcast</td><td class="p-3 text-surface-200 border-b border-surface-700">Every 15 min</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Bluetooth</td><td class="p-3 text-surface-200 border-b border-surface-700">Enabled (for phone app)</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Power Saving</td><td class="p-3 text-surface-200 border-b border-surface-700">Light sleep when idle</td></tr>
 				</tbody>
 			</table>
 		</div>
 
-		<div class="profile">
-			<div class="profile-header">
-				<h3>tdeck-pro-eink-client</h3>
-				<span class="role-badge client">CLIENT</span>
+		<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+			<div class="flex items-center gap-4 mb-3">
+				<h3 class="m-0 font-mono text-surface-100">tdeck-pro-eink-client</h3>
+				<span class="px-2 py-0.5 rounded text-xs font-semibold text-white bg-primary-500">CLIENT</span>
 			</div>
-			<p>E-ink device optimized for maximum battery life. Aggressive power saving.</p>
-			<table>
+			<p class="text-surface-400 m-0 mb-4">E-ink device optimized for maximum battery life. Aggressive power saving.</p>
+			<table class="w-full border-collapse mt-4">
 				<tbody>
-					<tr><td>Device Role</td><td>CLIENT</td></tr>
-					<tr><td>TX Power</td><td>22 dBm</td></tr>
-					<tr><td>Modem Preset</td><td>LONG_FAST</td></tr>
-					<tr><td>Hop Limit</td><td>5</td></tr>
-					<tr><td>GPS Interval</td><td>Every 5 min</td></tr>
-					<tr><td>Position Broadcast</td><td>Every 30 min</td></tr>
-					<tr><td>Bluetooth</td><td>Enabled</td></tr>
-					<tr><td>Power Saving</td><td>Deep sleep when idle</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Device Role</td><td class="p-3 text-surface-200 border-b border-surface-700">CLIENT</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">TX Power</td><td class="p-3 text-surface-200 border-b border-surface-700">22 dBm</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Modem Preset</td><td class="p-3 text-surface-200 border-b border-surface-700">LONG_FAST</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Hop Limit</td><td class="p-3 text-surface-200 border-b border-surface-700">5</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">GPS Interval</td><td class="p-3 text-surface-200 border-b border-surface-700">Every 5 min</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Position Broadcast</td><td class="p-3 text-surface-200 border-b border-surface-700">Every 30 min</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Bluetooth</td><td class="p-3 text-surface-200 border-b border-surface-700">Enabled</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Power Saving</td><td class="p-3 text-surface-200 border-b border-surface-700">Deep sleep when idle</td></tr>
 				</tbody>
 			</table>
 		</div>
 
-		<div class="profile">
-			<div class="profile-header">
-				<h3>meshadv-mini-gateway</h3>
-				<span class="role-badge gateway">ROUTER_CLIENT</span>
+		<div class="p-6 border border-surface-700 rounded-lg bg-surface-800">
+			<div class="flex items-center gap-4 mb-3">
+				<h3 class="m-0 font-mono text-surface-100">meshadv-mini-gateway</h3>
+				<span class="px-2 py-0.5 rounded text-xs font-semibold text-white bg-blue-500">ROUTER_CLIENT</span>
 			</div>
-			<p>Raspberry Pi HAT for SMS/email bridge and MQTT gateway duty. Always-on, wired power.</p>
-			<table>
+			<p class="text-surface-400 m-0 mb-4">Raspberry Pi HAT for SMS/email bridge and MQTT gateway duty. Always-on, wired power.</p>
+			<table class="w-full border-collapse mt-4">
 				<tbody>
-					<tr><td>Device Role</td><td>ROUTER_CLIENT</td></tr>
-					<tr><td>TX Power</td><td>22 dBm</td></tr>
-					<tr><td>Modem Preset</td><td>LONG_FAST</td></tr>
-					<tr><td>Hop Limit</td><td>5</td></tr>
-					<tr><td>MQTT</td><td>Enabled (local Mosquitto)</td></tr>
-					<tr><td>Serial</td><td>Enabled (debug logging)</td></tr>
-					<tr><td>Power Saving</td><td>Disabled (always-on)</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Device Role</td><td class="p-3 text-surface-200 border-b border-surface-700">ROUTER_CLIENT</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">TX Power</td><td class="p-3 text-surface-200 border-b border-surface-700">22 dBm</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Modem Preset</td><td class="p-3 text-surface-200 border-b border-surface-700">LONG_FAST</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Hop Limit</td><td class="p-3 text-surface-200 border-b border-surface-700">5</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">MQTT</td><td class="p-3 text-surface-200 border-b border-surface-700">Enabled (local Mosquitto)</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Serial</td><td class="p-3 text-surface-200 border-b border-surface-700">Enabled (debug logging)</td></tr>
+					<tr><td class="p-3 text-surface-200 border-b border-surface-700 font-semibold w-2/5">Power Saving</td><td class="p-3 text-surface-200 border-b border-surface-700">Disabled (always-on)</td></tr>
 				</tbody>
 			</table>
 		</div>
 	</div>
 </section>
 
-<section>
-	<h2>Applying a Profile</h2>
-	<pre class="code">{`# Apply with auto-backup
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Applying a Profile</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Apply with auto-backup
 just configure-profile station-g2-router /dev/ttyUSB0
 
 # Apply channels (reads PSK from operator keystore)
@@ -128,126 +128,3 @@ just configure-channels /dev/ttyUSB0
 # Verify configuration
 meshtastic --port /dev/ttyUSB0 --info`}</pre>
 </section>
-
-<style>
-	.breadcrumb {
-		font-size: 0.85rem;
-		color: #888;
-		margin-bottom: 1rem;
-	}
-
-	.breadcrumb a {
-		color: #00d4aa;
-		text-decoration: none;
-	}
-
-	.intro {
-		font-size: 1.1rem;
-		color: #555;
-		margin-bottom: 2rem;
-	}
-
-	section {
-		margin-bottom: 3rem;
-	}
-
-	.flowchart {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 1.5rem;
-		background: #f9f9f9;
-		border-radius: 8px;
-	}
-
-	.flow-step {
-		background: white;
-		border: 1px solid #ddd;
-		padding: 0.5rem 1rem;
-		border-radius: 6px;
-		font-weight: 500;
-	}
-
-	.flow-arrow {
-		color: #00d4aa;
-		font-weight: bold;
-		font-size: 0.85rem;
-	}
-
-	.flow-result {
-		background: #1a1a2e;
-		color: #00d4aa;
-		padding: 0.5rem 1rem;
-		border-radius: 6px;
-		font-family: monospace;
-	}
-
-	.profiles {
-		display: grid;
-		gap: 1.5rem;
-	}
-
-	.profile {
-		padding: 1.5rem;
-		border: 1px solid #ddd;
-		border-radius: 8px;
-		background: white;
-	}
-
-	.profile-header {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-		margin-bottom: 0.75rem;
-	}
-
-	.profile h3 {
-		margin: 0;
-		font-family: monospace;
-	}
-
-	.role-badge {
-		padding: 0.15rem 0.5rem;
-		border-radius: 4px;
-		font-size: 0.75rem;
-		font-weight: 600;
-		color: white;
-	}
-
-	.role-badge.router { background: #e74c3c; }
-	.role-badge.client { background: #00d4aa; }
-	.role-badge.gateway { background: #3498db; }
-
-	.profile p {
-		color: #555;
-		margin: 0 0 1rem;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-	}
-
-	td {
-		padding: 0.5rem 0.75rem;
-		border: 1px solid #eee;
-		font-size: 0.9rem;
-	}
-
-	td:first-child {
-		font-weight: 600;
-		color: #555;
-		width: 40%;
-	}
-
-	.code {
-		background: #1a1a2e;
-		color: #00d4aa;
-		padding: 1.25rem;
-		border-radius: 8px;
-		overflow-x: auto;
-		font-size: 0.85rem;
-		line-height: 1.5;
-	}
-</style>

--- a/site/src/routes/guides/firmware-flashing/+page.svelte
+++ b/site/src/routes/guides/firmware-flashing/+page.svelte
@@ -6,44 +6,44 @@
 	<title>Firmware Flashing - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Firmware Flashing
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Firmware Flashing
 </nav>
 
 <h1>Firmware Flashing Guide</h1>
-<p class="intro">Flash, verify, and configure Meshtastic firmware on LA-Mesh devices using the justfile pipeline.</p>
+<p class="text-lg text-surface-400 mb-8">Flash, verify, and configure Meshtastic firmware on LA-Mesh devices using the justfile pipeline.</p>
 
-<section class="warning">
-	<strong>Minimum Firmware Version: v2.7.15+</strong>
-	<p>Earlier versions are vulnerable to CVE-2025-52464 (duplicate crypto keys), CVE-2025-24797, CVE-2025-55293, CVE-2025-55292, and CVE-2025-53627. Do not deploy devices with firmware older than v2.7.15. Note: v2.7.15 enforces PKI-only DMs (legacy DMs disabled).</p>
-</section>
+<div class="p-5 bg-yellow-500/10 border border-yellow-500/30 rounded-lg mb-8">
+	<strong class="text-yellow-400">Minimum Firmware Version: v2.7.15+</strong>
+	<p class="text-yellow-300/80 mt-2 m-0">Earlier versions are vulnerable to CVE-2025-52464 (duplicate crypto keys), CVE-2025-24797, CVE-2025-55293, CVE-2025-55292, and CVE-2025-53627. Do not deploy devices with firmware older than v2.7.15. Note: v2.7.15 enforces PKI-only DMs (legacy DMs disabled).</p>
+</div>
 
-<section>
-	<h2>Method 1: One-Command Provisioning (Recommended)</h2>
-	<p>Clone the repo, enter the dev shell, and provision a device in one pipeline. This fetches the manifest-pinned firmware, verifies its SHA256 checksum, flashes it, applies the device profile, and configures LA-Mesh channels.</p>
-	<pre class="code">{`git clone https://github.com/Jesssullivan/LA-Mesh.git
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Method 1: One-Command Provisioning (Recommended)</h2>
+	<p class="text-surface-300 mb-4">Clone the repo, enter the dev shell, and provision a device in one pipeline. This fetches the manifest-pinned firmware, verifies its SHA256 checksum, flashes it, applies the device profile, and configures LA-Mesh channels.</p>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`git clone https://github.com/Jesssullivan/LA-Mesh.git
 cd LA-Mesh
 direnv allow                                    # or: nix develop
 just provision station-g2 /dev/ttyUSB0`}</pre>
 
-	<h3>What <code>just provision</code> does</h3>
-	<table>
-		<thead><tr><th>Step</th><th>Action</th><th>Detail</th></tr></thead>
+	<h3 class="text-surface-100 mt-6">What <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just provision</code> does</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Step</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Detail</th></tr></thead>
 		<tbody>
-			<tr><td>1</td><td>Fetch firmware</td><td>Downloads pinned version from GitHub (cached locally)</td></tr>
-			<tr><td>2</td><td>Verify checksum</td><td>SHA256 checked against <code>firmware/manifest.json</code></td></tr>
-			<tr><td>3</td><td>Flash device</td><td>esptool.py <code>write-flash</code> at offset <code>0x260000</code></td></tr>
-			<tr><td>4</td><td>Apply profile</td><td>Device role config (ROUTER, CLIENT, etc.)</td></tr>
-			<tr><td>5</td><td>Set channels</td><td>LA-Mesh / LA-Admin / LA-Emergency (requires PSK from operator's encrypted keystore)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">1</td><td class="p-3 text-surface-200 border-b border-surface-700">Fetch firmware</td><td class="p-3 text-surface-200 border-b border-surface-700">Downloads pinned version from GitHub (cached locally)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">2</td><td class="p-3 text-surface-200 border-b border-surface-700">Verify checksum</td><td class="p-3 text-surface-200 border-b border-surface-700">SHA256 checked against <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">firmware/manifest.json</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">3</td><td class="p-3 text-surface-200 border-b border-surface-700">Flash device</td><td class="p-3 text-surface-200 border-b border-surface-700">esptool.py <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">write-flash</code> at offset <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">0x260000</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">4</td><td class="p-3 text-surface-200 border-b border-surface-700">Apply profile</td><td class="p-3 text-surface-200 border-b border-surface-700">Device role config (ROUTER, CLIENT, etc.)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">5</td><td class="p-3 text-surface-200 border-b border-surface-700">Set channels</td><td class="p-3 text-surface-200 border-b border-surface-700">LA-Mesh / LA-Admin / LA-Emergency (requires PSK from operator's encrypted keystore)</td></tr>
 		</tbody>
 	</table>
-	<p>Device types: <code>station-g2</code>, <code>t-deck</code></p>
+	<p class="text-surface-300 mb-4">Device types: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">station-g2</code>, <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">t-deck</code></p>
 </section>
 
-<section>
-	<h2>Method 2: Step-by-Step CLI</h2>
-	<p>For operators who want explicit control over each stage.</p>
-	<pre class="code">{`# 1. Fetch firmware for a specific device
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Method 2: Step-by-Step CLI</h2>
+	<p class="text-surface-300 mb-4">For operators who want explicit control over each stage.</p>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# 1. Fetch firmware for a specific device
 just fetch-firmware --device station-g2
 
 # 2. Confirm pinned version
@@ -59,166 +59,87 @@ just configure-profile station-g2-router /dev/ttyUSB0
 just configure-channels /dev/ttyUSB0`}</pre>
 </section>
 
-<section>
-	<h2>Method 3: Web Flasher</h2>
-	<p>For meetups or field use when the dev environment is unavailable.</p>
-	<ol>
-		<li>Connect device via USB-C (use a data cable, not charge-only)</li>
-		<li>Open <code>flasher.meshtastic.org</code> in Chrome or Edge (WebSerial required)</li>
-		<li>Select your device type and firmware version</li>
-		<li>Click "Flash" and wait for completion (~2 minutes)</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Method 3: Web Flasher</h2>
+	<p class="text-surface-300 mb-4">For meetups or field use when the dev environment is unavailable.</p>
+	<ol class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Connect device via USB-C (use a data cable, not charge-only)</li>
+		<li class="mb-1">Open <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">flasher.meshtastic.org</code> in Chrome or Edge (WebSerial required)</li>
+		<li class="mb-1">Select your device type and firmware version</li>
+		<li class="mb-1">Click "Flash" and wait for completion (~2 minutes)</li>
 	</ol>
-	<p class="note">Web flasher does not verify against the LA-Mesh manifest. After flashing, apply the profile and channels manually via CLI.</p>
+	<p class="text-sm text-surface-400 italic">Web flasher does not verify against the LA-Mesh manifest. After flashing, apply the profile and channels manually via CLI.</p>
 </section>
 
-<section>
-	<h2>Checksum Verification</h2>
-	<p>All justfile flash commands verify firmware integrity automatically:</p>
-	<ul>
-		<li><code>firmware/manifest.json</code> pins the exact version and SHA256 hash per device</li>
-		<li><code>just fetch-firmware</code> verifies the hash on download</li>
-		<li><code>just flash-meshtastic</code> verifies the hash before flashing</li>
-		<li><code>just provision</code> verifies the hash at step 2 -- refuses to flash on mismatch</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Checksum Verification</h2>
+	<p class="text-surface-300 mb-4">All justfile flash commands verify firmware integrity automatically:</p>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">firmware/manifest.json</code> pins the exact version and SHA256 hash per device</li>
+		<li class="mb-1"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just fetch-firmware</code> verifies the hash on download</li>
+		<li class="mb-1"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just flash-meshtastic</code> verifies the hash before flashing</li>
+		<li class="mb-1"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just provision</code> verifies the hash at step 2 -- refuses to flash on mismatch</li>
 	</ul>
-	<pre class="code">{`# After first download, populate manifest hashes
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# After first download, populate manifest hashes
 just firmware-update-hashes
 
 # Verify what's pinned
 just firmware-versions`}</pre>
-	<p>If you see <strong>"CHECKSUM MISMATCH -- refusing to flash!"</strong>, the binary is corrupted or does not match the manifest. Re-download with <code>just fetch-firmware</code>.</p>
+	<p class="text-surface-300 mb-4">If you see <strong>"CHECKSUM MISMATCH -- refusing to flash!"</strong>, the binary is corrupted or does not match the manifest. Re-download with <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just fetch-firmware</code>.</p>
 </section>
 
-<section>
-	<h2>Version Parity</h2>
-	<p>All devices provisioned from the same repo clone get identical firmware versions -- the manifest is the single source of truth.</p>
-	<pre class="code">{`# Check pinned versions
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Version Parity</h2>
+	<p class="text-surface-300 mb-4">All devices provisioned from the same repo clone get identical firmware versions -- the manifest is the single source of truth.</p>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Check pinned versions
 just firmware-versions
 
 # Check if upstream has a newer release
 just firmware-check`}</pre>
-	<p>To update the pinned version: edit <code>firmware/manifest.json</code>, run <code>just fetch-firmware</code>, then <code>just firmware-update-hashes</code>.</p>
+	<p class="text-surface-300 mb-4">To update the pinned version: edit <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">firmware/manifest.json</code>, run <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just fetch-firmware</code>, then <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just firmware-update-hashes</code>.</p>
 </section>
 
-<section>
-	<h2>Post-Flash Configuration</h2>
-	<table>
-		<thead><tr><th>Device</th><th>Profile</th><th>Command</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Post-Flash Configuration</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Device</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Profile</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Command</th></tr></thead>
 		<tbody>
 			<tr>
-				<td>Station G2 (relay)</td>
-				<td>station-g2-router</td>
-				<td><code>just configure-profile station-g2-router</code></td>
+				<td class="p-3 text-surface-200 border-b border-surface-700">Station G2 (relay)</td>
+				<td class="p-3 text-surface-200 border-b border-surface-700">station-g2-router</td>
+				<td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just configure-profile station-g2-router</code></td>
 			</tr>
 			<tr>
-				<td>T-Deck Plus</td>
-				<td>tdeck-plus-client</td>
-				<td><code>just configure-profile tdeck-plus-client</code></td>
+				<td class="p-3 text-surface-200 border-b border-surface-700">T-Deck Plus</td>
+				<td class="p-3 text-surface-200 border-b border-surface-700">tdeck-plus-client</td>
+				<td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just configure-profile tdeck-plus-client</code></td>
 			</tr>
 			<tr>
-				<td>T-Deck Pro (e-ink)</td>
-				<td>tdeck-pro-eink-client</td>
-				<td><code>just configure-profile tdeck-pro-eink-client</code></td>
+				<td class="p-3 text-surface-200 border-b border-surface-700">T-Deck Pro (e-ink)</td>
+				<td class="p-3 text-surface-200 border-b border-surface-700">tdeck-pro-eink-client</td>
+				<td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just configure-profile tdeck-pro-eink-client</code></td>
 			</tr>
 			<tr>
-				<td>MeshAdv-Mini</td>
-				<td>meshadv-mini-gateway</td>
-				<td><code>just configure-profile meshadv-mini-gateway</code></td>
+				<td class="p-3 text-surface-200 border-b border-surface-700">MeshAdv-Mini</td>
+				<td class="p-3 text-surface-200 border-b border-surface-700">meshadv-mini-gateway</td>
+				<td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just configure-profile meshadv-mini-gateway</code></td>
 			</tr>
 		</tbody>
 	</table>
-	<p>Then apply LA-Mesh channel configuration (requires PSK from operator's encrypted keystore):</p>
-	<pre class="code">{`just configure-channels /dev/ttyUSB0`}</pre>
+	<p class="text-surface-300 mb-4">Then apply LA-Mesh channel configuration (requires PSK from operator's encrypted keystore):</p>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`just configure-channels /dev/ttyUSB0`}</pre>
 </section>
 
-<section>
-	<h2>Troubleshooting</h2>
-	<table>
-		<thead><tr><th>Error</th><th>Solution</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Troubleshooting</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Error</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Solution</th></tr></thead>
 		<tbody>
-			<tr><td>"Failed to connect"</td><td>Enter bootloader mode (BOOT + RESET)</td></tr>
-			<tr><td>"CHECKSUM MISMATCH"</td><td>Re-download: <code>just fetch-firmware</code>, then <code>just firmware-update-hashes</code></td></tr>
-			<tr><td>"Invalid head of packet"</td><td>Erase flash first: <code>just flash-erase</code></td></tr>
-			<tr><td>"Timed out"</td><td>Try lower baud rate (115200 instead of 921600)</td></tr>
-			<tr><td>Permission denied</td><td><code>sudo usermod -aG dialout $USER</code> (re-login required)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">"Failed to connect"</td><td class="p-3 text-surface-200 border-b border-surface-700">Enter bootloader mode (BOOT + RESET)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">"CHECKSUM MISMATCH"</td><td class="p-3 text-surface-200 border-b border-surface-700">Re-download: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just fetch-firmware</code>, then <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just firmware-update-hashes</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">"Invalid head of packet"</td><td class="p-3 text-surface-200 border-b border-surface-700">Erase flash first: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just flash-erase</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">"Timed out"</td><td class="p-3 text-surface-200 border-b border-surface-700">Try lower baud rate (115200 instead of 921600)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Permission denied</td><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">sudo usermod -aG dialout $USER</code> (re-login required)</td></tr>
 		</tbody>
 	</table>
 </section>
-
-<style>
-	.breadcrumb {
-		font-size: 0.85rem;
-		color: #888;
-		margin-bottom: 1rem;
-	}
-
-	.breadcrumb a {
-		color: #00d4aa;
-		text-decoration: none;
-	}
-
-	.intro {
-		font-size: 1.1rem;
-		color: #555;
-		margin-bottom: 2rem;
-	}
-
-	section {
-		margin-bottom: 3rem;
-	}
-
-	.warning {
-		background: #fff3cd;
-		border: 1px solid #ffc107;
-		border-radius: 8px;
-		padding: 1.25rem;
-	}
-
-	.warning strong {
-		color: #856404;
-	}
-
-	.warning p {
-		margin: 0.5rem 0 0;
-		color: #856404;
-	}
-
-	.code {
-		background: #1a1a2e;
-		color: #00d4aa;
-		padding: 1.25rem;
-		border-radius: 8px;
-		overflow-x: auto;
-		font-size: 0.85rem;
-		line-height: 1.5;
-	}
-
-	code {
-		background: #f0f0f0;
-		padding: 0.15rem 0.35rem;
-		border-radius: 3px;
-		font-size: 0.85rem;
-	}
-
-	.note {
-		font-size: 0.9rem;
-		color: #888;
-		font-style: italic;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-		margin-top: 1rem;
-	}
-
-	th, td {
-		padding: 0.75rem;
-		border: 1px solid #ddd;
-		text-align: left;
-	}
-
-	th {
-		background: #f5f5f5;
-		font-weight: 600;
-	}
-</style>

--- a/site/src/routes/guides/firmware-switching/+page.svelte
+++ b/site/src/routes/guides/firmware-switching/+page.svelte
@@ -6,44 +6,44 @@
 	<title>Firmware Switching - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Firmware Switching
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Firmware Switching
 </nav>
 
 <h1>Firmware Switching: Meshtastic &lt;-&gt; MeshCore</h1>
-<p class="intro">Switch between Meshtastic and MeshCore firmware on ESP32-S3 devices. Use a dedicated evaluation device -- never your primary LA-Mesh node.</p>
+<p class="text-lg text-surface-400 mb-8">Switch between Meshtastic and MeshCore firmware on ESP32-S3 devices. Use a dedicated evaluation device -- never your primary LA-Mesh node.</p>
 
-<section class="warning">
-	<strong>No dual-boot capability.</strong>
-	<p>MeshCore and Meshtastic use incompatible partition tables, NVS schemas, and radio configurations. Switching requires a full flash erase (~60 seconds total).</p>
-</section>
+<div class="p-5 bg-yellow-500/10 border border-yellow-500/30 rounded-lg mb-8">
+	<strong class="text-yellow-400">No dual-boot capability.</strong>
+	<p class="text-yellow-300/80 mt-2 m-0">MeshCore and Meshtastic use incompatible partition tables, NVS schemas, and radio configurations. Switching requires a full flash erase (~60 seconds total).</p>
+</div>
 
-<section>
-	<h2>Incompatibility Summary</h2>
-	<table>
-		<thead><tr><th>Aspect</th><th>Meshtastic</th><th>MeshCore</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Incompatibility Summary</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Aspect</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Meshtastic</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">MeshCore</th></tr></thead>
 		<tbody>
-			<tr><td>Partition table</td><td>Custom (app + littlefs)</td><td>Different layout</td></tr>
-			<tr><td>Configuration</td><td>YAML profiles via CLI</td><td>Web config tool</td></tr>
-			<tr><td>Channel format</td><td>PSK + channel index</td><td>Room/password model</td></tr>
-			<tr><td>Encryption</td><td>AES-256-CTR + X25519 PKC</td><td>AES-128-ECB</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Partition table</td><td class="p-3 text-surface-200 border-b border-surface-700">Custom (app + littlefs)</td><td class="p-3 text-surface-200 border-b border-surface-700">Different layout</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Configuration</td><td class="p-3 text-surface-200 border-b border-surface-700">YAML profiles via CLI</td><td class="p-3 text-surface-200 border-b border-surface-700">Web config tool</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Channel format</td><td class="p-3 text-surface-200 border-b border-surface-700">PSK + channel index</td><td class="p-3 text-surface-200 border-b border-surface-700">Room/password model</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Encryption</td><td class="p-3 text-surface-200 border-b border-surface-700">AES-256-CTR + X25519 PKC</td><td class="p-3 text-surface-200 border-b border-surface-700">AES-128-ECB</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Before Switching: Back Up</h2>
-	<pre class="code">{`# Export current Meshtastic config
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Before Switching: Back Up</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Export current Meshtastic config
 meshtastic --export-config > backup-meshtastic-$(date +%Y%m%d).yaml
 
 # Record firmware version
 meshtastic --info | grep Firmware`}</pre>
-	<p>Flash erase destroys all state. Configuration, message history, node list, and Bluetooth pairings are lost.</p>
+	<p class="text-surface-300 mb-4">Flash erase destroys all state. Configuration, message history, node list, and Bluetooth pairings are lost.</p>
 </section>
 
-<section>
-	<h2>Switch to MeshCore (Evaluation)</h2>
-	<pre class="code">{`# 1. Erase flash (hold BOOT, press RESET, release BOOT first)
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Switch to MeshCore (Evaluation)</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# 1. Erase flash (hold BOOT, press RESET, release BOOT first)
 just flash-erase /dev/ttyUSB0
 
 # 2. Flash MeshCore via web flasher (recommended)
@@ -54,9 +54,9 @@ just flash-meshcore meshcore-firmware.bin /dev/ttyUSB0
 # 3. Configure via https://config.meshcore.co.uk`}</pre>
 </section>
 
-<section>
-	<h2>Switch Back to Meshtastic</h2>
-	<pre class="code">{`# 1. Erase flash
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Switch Back to Meshtastic</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# 1. Erase flash
 just flash-erase /dev/ttyUSB0
 
 # 2. One-command provisioning (fetch + verify + flash + configure)
@@ -66,36 +66,21 @@ just provision station-g2 /dev/ttyUSB0
 meshtastic --configure backup-meshtastic-YYYYMMDD.yaml`}</pre>
 </section>
 
-<section>
-	<h2>Automated Switch Script</h2>
-	<pre class="code">{`just switch-firmware /dev/ttyUSB0`}</pre>
-	<p>Interactive script that backs up, erases, flashes, and configures in one flow.</p>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Automated Switch Script</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`just switch-firmware /dev/ttyUSB0`}</pre>
+	<p class="text-surface-300 mb-4">Interactive script that backs up, erases, flashes, and configures in one flow.</p>
 </section>
 
-<section>
-	<h2>Quick Reference</h2>
-	<table>
-		<thead><tr><th>Action</th><th>Time</th><th>Command</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Quick Reference</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Time</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Command</th></tr></thead>
 		<tbody>
-			<tr><td>Erase flash</td><td>~5s</td><td><code>just flash-erase /dev/ttyUSB0</code></td></tr>
-			<tr><td>Flash + configure Meshtastic</td><td>~45s</td><td><code>just provision station-g2 /dev/ttyUSB0</code></td></tr>
-			<tr><td>Flash MeshCore</td><td>~30s</td><td>Web flasher or <code>just flash-meshcore</code></td></tr>
-			<tr><td>Total switch time</td><td>~60s</td><td>Erase + flash + configure</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Erase flash</td><td class="p-3 text-surface-200 border-b border-surface-700">~5s</td><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just flash-erase /dev/ttyUSB0</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Flash + configure Meshtastic</td><td class="p-3 text-surface-200 border-b border-surface-700">~45s</td><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just provision station-g2 /dev/ttyUSB0</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Flash MeshCore</td><td class="p-3 text-surface-200 border-b border-surface-700">~30s</td><td class="p-3 text-surface-200 border-b border-surface-700">Web flasher or <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just flash-meshcore</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Total switch time</td><td class="p-3 text-surface-200 border-b border-surface-700">~60s</td><td class="p-3 text-surface-200 border-b border-surface-700">Erase + flash + configure</td></tr>
 		</tbody>
 	</table>
 </section>
-
-<style>
-	.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1rem; }
-	.breadcrumb a { color: #00d4aa; text-decoration: none; }
-	.intro { font-size: 1.1rem; color: #555; margin-bottom: 2rem; }
-	section { margin-bottom: 3rem; }
-	.warning { background: #fff3cd; border: 1px solid #ffc107; border-radius: 8px; padding: 1.25rem; }
-	.warning strong { color: #856404; }
-	.warning p { margin: 0.5rem 0 0; color: #856404; }
-	.code { background: #1a1a2e; color: #00d4aa; padding: 1.25rem; border-radius: 8px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
-	table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-	th, td { padding: 0.75rem; border: 1px solid #ddd; text-align: left; }
-	th { background: #f5f5f5; font-weight: 600; }
-	a { color: #00d4aa; }
-</style>

--- a/site/src/routes/guides/gpg/+page.svelte
+++ b/site/src/routes/guides/gpg/+page.svelte
@@ -6,45 +6,45 @@
 	<title>GPG Guide - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / GPG
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / GPG
 </nav>
 
 <h1>GPG Quick Start</h1>
-<p class="intro">Generate keys, sign and encrypt messages, verify firmware downloads, and publish your public key.</p>
+<p class="text-lg text-surface-400 mb-8">Generate keys, sign and encrypt messages, verify firmware downloads, and publish your public key.</p>
 
-<section>
-	<h2>What GPG Does for LA-Mesh</h2>
-	<ul>
-		<li>Verify GPG signatures on email bridge messages</li>
-		<li>Sign and encrypt arbitrary messages for specific recipients over insecure channels</li>
-		<li>Verify downloaded firmware and TAILS ISO integrity</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">What GPG Does for LA-Mesh</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Verify GPG signatures on email bridge messages</li>
+		<li class="mb-1">Sign and encrypt arbitrary messages for specific recipients over insecure channels</li>
+		<li class="mb-1">Verify downloaded firmware and TAILS ISO integrity</li>
 	</ul>
 </section>
 
-<section>
-	<h2>Generate a Key Pair (Ed25519)</h2>
-	<pre class="code">{`# Generate Ed25519 signing key + cv25519 encryption subkey
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Generate a Key Pair (Ed25519)</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Generate Ed25519 signing key + cv25519 encryption subkey
 gpg --quick-gen-key "Your Name <you@example.com>" ed25519 cert 0
 # Add encryption subkey
 gpg --quick-add-key $(gpg -k --with-colons you@example.com | \\
   grep fpr | head -1 | cut -d: -f10) cv25519 encr 0`}</pre>
-	<p>Ed25519 keys are shorter, faster, and more secure than RSA-4096 for modern use.</p>
+	<p class="text-surface-300 mb-4">Ed25519 keys are shorter, faster, and more secure than RSA-4096 for modern use.</p>
 </section>
 
-<section>
-	<h2>Publish Your Public Key</h2>
-	<pre class="code">{`# Upload to keyserver
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Publish Your Public Key</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Upload to keyserver
 gpg --keyserver hkps://keys.openpgp.org --send-keys <KEY-ID>
 
 # Export for in-person exchange via QR code
 gpg --export <KEY-ID> | qrencode -o pubkey-qr.png`}</pre>
-	<p>Keyserver: <a href="https://keys.openpgp.org">keys.openpgp.org</a></p>
+	<p class="text-surface-300 mb-4">Keyserver: <a href="https://keys.openpgp.org" class="text-primary-400">keys.openpgp.org</a></p>
 </section>
 
-<section>
-	<h2>Sign and Encrypt</h2>
-	<pre class="code">{`# Clearsign a message (readable + signature)
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Sign and Encrypt</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Clearsign a message (readable + signature)
 gpg --clearsign message.txt
 
 # Encrypt for a specific recipient
@@ -54,36 +54,24 @@ gpg --encrypt --armor --recipient recipient@example.com message.txt
 gpg --verify message.txt.asc`}</pre>
 </section>
 
-<section>
-	<h2>Verify Downloaded Files</h2>
-	<pre class="code">{`# Verify firmware release signature
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Verify Downloaded Files</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Verify firmware release signature
 gpg --verify firmware-2.7.15.zip.sig firmware-2.7.15.zip
 
 # Verify TAILS ISO
 gpg --verify tails-amd64-7.4.2.iso.sig tails-amd64-7.4.2.iso`}</pre>
 </section>
 
-<section>
-	<h2>Client Setup</h2>
-	<table>
-		<thead><tr><th>Platform</th><th>Client</th><th>Notes</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Client Setup</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Platform</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Client</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Notes</th></tr></thead>
 		<tbody>
-			<tr><td>Thunderbird</td><td>Built-in OpenPGP</td><td>No Enigmail needed (Thunderbird 78+)</td></tr>
-			<tr><td>TAILS</td><td>Kleopatra (built-in)</td><td>GUI key manager included in TAILS</td></tr>
-			<tr><td>Linux CLI</td><td>gpg</td><td>Installed by default on most distributions</td></tr>
-			<tr><td>macOS</td><td>GPG Suite</td><td>Integrates with Apple Mail</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Thunderbird</td><td class="p-3 text-surface-200 border-b border-surface-700">Built-in OpenPGP</td><td class="p-3 text-surface-200 border-b border-surface-700">No Enigmail needed (Thunderbird 78+)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">TAILS</td><td class="p-3 text-surface-200 border-b border-surface-700">Kleopatra (built-in)</td><td class="p-3 text-surface-200 border-b border-surface-700">GUI key manager included in TAILS</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Linux CLI</td><td class="p-3 text-surface-200 border-b border-surface-700">gpg</td><td class="p-3 text-surface-200 border-b border-surface-700">Installed by default on most distributions</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">macOS</td><td class="p-3 text-surface-200 border-b border-surface-700">GPG Suite</td><td class="p-3 text-surface-200 border-b border-surface-700">Integrates with Apple Mail</td></tr>
 		</tbody>
 	</table>
 </section>
-
-<style>
-	.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1rem; }
-	.breadcrumb a { color: #00d4aa; text-decoration: none; }
-	.intro { font-size: 1.1rem; color: #555; margin-bottom: 2rem; }
-	section { margin-bottom: 3rem; }
-	.code { background: #1a1a2e; color: #00d4aa; padding: 1.25rem; border-radius: 8px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
-	table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-	th, td { padding: 0.75rem; border: 1px solid #ddd; text-align: left; }
-	th { background: #f5f5f5; font-weight: 600; }
-	a { color: #00d4aa; }
-</style>

--- a/site/src/routes/guides/key-management/+page.svelte
+++ b/site/src/routes/guides/key-management/+page.svelte
@@ -6,86 +6,74 @@
 	<title>Key Management - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Key Management
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Key Management
 </nav>
 
 <h1>Key Management Guide</h1>
-<p class="intro">PSK lifecycle, operator roles, key rotation procedures, and credential management for LA-Mesh.</p>
+<p class="text-lg text-surface-400 mb-8">PSK lifecycle, operator roles, key rotation procedures, and credential management for LA-Mesh.</p>
 
-<section>
-	<h2>Key Types</h2>
-	<table>
-		<thead><tr><th>Key</th><th>Type</th><th>Stored Where</th><th>Rotated</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Key Types</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Key</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Type</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Stored Where</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Rotated</th></tr></thead>
 		<tbody>
-			<tr><td>Channel PSK (x3)</td><td>Symmetric (AES-256)</td><td>Operator encrypted storage</td><td>Quarterly</td></tr>
-			<tr><td>Device PKC key pair</td><td>Asymmetric (X25519)</td><td>On-device only</td><td>On firmware update</td></tr>
-			<tr><td>MQTT credentials</td><td>Username/password</td><td>Encrypted keystore (KeePassXC)</td><td>On compromise</td></tr>
-			<tr><td>SMTP credentials</td><td>API token</td><td>Encrypted keystore (KeePassXC)</td><td>On compromise</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Channel PSK (x3)</td><td class="p-3 text-surface-200 border-b border-surface-700">Symmetric (AES-256)</td><td class="p-3 text-surface-200 border-b border-surface-700">Operator encrypted storage</td><td class="p-3 text-surface-200 border-b border-surface-700">Quarterly</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Device PKC key pair</td><td class="p-3 text-surface-200 border-b border-surface-700">Asymmetric (X25519)</td><td class="p-3 text-surface-200 border-b border-surface-700">On-device only</td><td class="p-3 text-surface-200 border-b border-surface-700">On firmware update</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">MQTT credentials</td><td class="p-3 text-surface-200 border-b border-surface-700">Username/password</td><td class="p-3 text-surface-200 border-b border-surface-700">Encrypted keystore (KeePassXC)</td><td class="p-3 text-surface-200 border-b border-surface-700">On compromise</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">SMTP credentials</td><td class="p-3 text-surface-200 border-b border-surface-700">API token</td><td class="p-3 text-surface-200 border-b border-surface-700">Encrypted keystore (KeePassXC)</td><td class="p-3 text-surface-200 border-b border-surface-700">On compromise</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>PSK Generation</h2>
-	<pre class="code">{`# Generate a 256-bit random PSK on a trusted machine
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">PSK Generation</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Generate a 256-bit random PSK on a trusted machine
 openssl rand -base64 32`}</pre>
-	<p>Produces a key like: <code>K7xR2p4mN8vQwY3jH6fL0tBuI9sDcE5gA1rO7kZ4hXs=</code></p>
+	<p class="text-surface-300 mb-4">Produces a key like: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">K7xR2p4mN8vQwY3jH6fL0tBuI9sDcE5gA1rO7kZ4hXs=</code></p>
 </section>
 
-<section>
-	<h2>PSK Distribution Rules</h2>
-	<ol>
-		<li>Generate on an air-gapped device or trusted machine</li>
-		<li>Distribute ONLY in person, face-to-face</li>
-		<li>Never send via text, email, Signal, or any digital channel</li>
-		<li>Write on paper, show screen, or use QR code in-person</li>
-		<li>Destroy paper copies after devices are configured</li>
-		<li>Rotate quarterly or immediately on suspected compromise</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">PSK Distribution Rules</h2>
+	<ol class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Generate on an air-gapped device or trusted machine</li>
+		<li class="mb-1">Distribute ONLY in person, face-to-face</li>
+		<li class="mb-1">Never send via text, email, Signal, or any digital channel</li>
+		<li class="mb-1">Write on paper, show screen, or use QR code in-person</li>
+		<li class="mb-1">Destroy paper copies after devices are configured</li>
+		<li class="mb-1">Rotate quarterly or immediately on suspected compromise</li>
 	</ol>
 </section>
 
-<section>
-	<h2>PSK Application</h2>
-	<pre class="code">{`# Apply PSK to device
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">PSK Application</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Apply PSK to device
 meshtastic --ch-set psk "<base64-psk>" --ch-index 0
 
 # Verify
 meshtastic --info`}</pre>
 </section>
 
-<section>
-	<h2>Compromise Response</h2>
-	<table>
-		<thead><tr><th>Event</th><th>Action</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Compromise Response</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Event</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th></tr></thead>
 		<tbody>
-			<tr><td>Suspected PSK leak</td><td>Rotate affected channel immediately</td></tr>
-			<tr><td>Device theft</td><td>Rotate all channels, attempt remote wipe via admin channel</td></tr>
-			<tr><td>Firmware vulnerability</td><td>Update all devices, rotate PKC keys if needed</td></tr>
-			<tr><td>Operator departure</td><td>Rotate admin channel PSK</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Suspected PSK leak</td><td class="p-3 text-surface-200 border-b border-surface-700">Rotate affected channel immediately</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Device theft</td><td class="p-3 text-surface-200 border-b border-surface-700">Rotate all channels, attempt remote wipe via admin channel</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Firmware vulnerability</td><td class="p-3 text-surface-200 border-b border-surface-700">Update all devices, rotate PKC keys if needed</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Operator departure</td><td class="p-3 text-surface-200 border-b border-surface-700">Rotate admin channel PSK</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Recommended Tools</h2>
-	<table>
-		<thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Recommended Tools</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Tool</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Purpose</th></tr></thead>
 		<tbody>
-			<tr><td><a href="https://keepassxc.org">KeePassXC</a></td><td>Offline AES-256 encrypted credential storage for PSKs, MQTT/SMTP credentials, and API tokens</td></tr>
-			<tr><td><a href="https://conversations.im/omemo/">OMEMO</a></td><td>Signal Protocol over federated XMPP -- end-to-end encrypted messaging for operator coordination</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><a href="https://keepassxc.org" class="text-primary-400">KeePassXC</a></td><td class="p-3 text-surface-200 border-b border-surface-700">Offline AES-256 encrypted credential storage for PSKs, MQTT/SMTP credentials, and API tokens</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><a href="https://conversations.im/omemo/" class="text-primary-400">OMEMO</a></td><td class="p-3 text-surface-200 border-b border-surface-700">Signal Protocol over federated XMPP -- end-to-end encrypted messaging for operator coordination</td></tr>
 		</tbody>
 	</table>
 </section>
-
-<style>
-	.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1rem; }
-	.breadcrumb a { color: #00d4aa; text-decoration: none; }
-	.intro { font-size: 1.1rem; color: #555; margin-bottom: 2rem; }
-	section { margin-bottom: 3rem; }
-	.code { background: #1a1a2e; color: #00d4aa; padding: 1.25rem; border-radius: 8px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
-	code { background: #f0f0f0; padding: 0.15rem 0.35rem; border-radius: 3px; font-size: 0.85rem; }
-	table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-	th, td { padding: 0.75rem; border: 1px solid #ddd; text-align: left; }
-	th { background: #f5f5f5; font-weight: 600; }
-</style>

--- a/site/src/routes/guides/node-deployment/+page.svelte
+++ b/site/src/routes/guides/node-deployment/+page.svelte
@@ -6,66 +6,66 @@
 	<title>Node Deployment - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Node Deployment
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Node Deployment
 </nav>
 
 <h1>Node Deployment Guide</h1>
-<p class="intro">Site survey, hardware preparation, installation, verification, and monitoring for fixed infrastructure nodes.</p>
+<p class="text-lg text-surface-400 mb-8">Site survey, hardware preparation, installation, verification, and monitoring for fixed infrastructure nodes.</p>
 
-<section>
-	<h2>Deployment Phases</h2>
-	<ol>
-		<li>Site survey and approval</li>
-		<li>Hardware preparation</li>
-		<li>Physical installation</li>
-		<li>Configuration and verification</li>
-		<li>Monitoring and maintenance</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Deployment Phases</h2>
+	<ol class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Site survey and approval</li>
+		<li class="mb-1">Hardware preparation</li>
+		<li class="mb-1">Physical installation</li>
+		<li class="mb-1">Configuration and verification</li>
+		<li class="mb-1">Monitoring and maintenance</li>
 	</ol>
 </section>
 
-<section>
-	<h2>Phase 1: Site Survey</h2>
-	<table>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Phase 1: Site Survey</h2>
+	<table class="w-full border-collapse mt-4">
 		<thead>
-			<tr><th>Criterion</th><th>Requirement</th></tr>
+			<tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Criterion</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Requirement</th></tr>
 		</thead>
 		<tbody>
-			<tr><td>Elevation</td><td>Highest available point with clear line-of-sight</td></tr>
-			<tr><td>Power</td><td>Continuous 5V USB-C (mains or solar + battery)</td></tr>
-			<tr><td>Access</td><td>Physical access for maintenance (quarterly minimum)</td></tr>
-			<tr><td>Permission</td><td>Written approval from property owner/manager</td></tr>
-			<tr><td>RF environment</td><td>Minimal 915 MHz interference (check with SDR)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Elevation</td><td class="p-3 text-surface-200 border-b border-surface-700">Highest available point with clear line-of-sight</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Power</td><td class="p-3 text-surface-200 border-b border-surface-700">Continuous 5V USB-C (mains or solar + battery)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Access</td><td class="p-3 text-surface-200 border-b border-surface-700">Physical access for maintenance (quarterly minimum)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Permission</td><td class="p-3 text-surface-200 border-b border-surface-700">Written approval from property owner/manager</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">RF environment</td><td class="p-3 text-surface-200 border-b border-surface-700">Minimal 915 MHz interference (check with SDR)</td></tr>
 		</tbody>
 	</table>
-	<p>Use <a href="https://site.meshtastic.org">Meshtastic Site Planner</a> for terrain analysis and coverage prediction.</p>
+	<p class="text-surface-300 mb-4">Use <a href="https://site.meshtastic.org" class="text-primary-400">Meshtastic Site Planner</a> for terrain analysis and coverage prediction.</p>
 </section>
 
-<section>
-	<h2>Phase 2: Hardware Preparation</h2>
-	<ol>
-		<li>Flash firmware: <code>just provision station-g2 /dev/ttyUSB0</code></li>
-		<li>Verify firmware v2.7.15+: <code>meshtastic --info</code></li>
-		<li>Run bench test suite before deployment</li>
-		<li>Assemble enclosure with cable glands and desiccant</li>
-		<li>Test antenna (SWR check if meter available)</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Phase 2: Hardware Preparation</h2>
+	<ol class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Flash firmware: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just provision station-g2 /dev/ttyUSB0</code></li>
+		<li class="mb-1">Verify firmware v2.7.15+: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">meshtastic --info</code></li>
+		<li class="mb-1">Run bench test suite before deployment</li>
+		<li class="mb-1">Assemble enclosure with cable glands and desiccant</li>
+		<li class="mb-1">Test antenna (SWR check if meter available)</li>
 	</ol>
 </section>
 
-<section>
-	<h2>Phase 3: Installation</h2>
-	<ul>
-		<li>Mount enclosure with appropriate hardware (Tapcon for masonry, stainless for wood)</li>
-		<li>Route antenna cable with drip loop to prevent water ingress</li>
-		<li>Apply dielectric grease to all SMA connections</li>
-		<li>Seal cable glands with marine silicone</li>
-		<li>Connect power (verify voltage before connecting device)</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Phase 3: Installation</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Mount enclosure with appropriate hardware (Tapcon for masonry, stainless for wood)</li>
+		<li class="mb-1">Route antenna cable with drip loop to prevent water ingress</li>
+		<li class="mb-1">Apply dielectric grease to all SMA connections</li>
+		<li class="mb-1">Seal cable glands with marine silicone</li>
+		<li class="mb-1">Connect power (verify voltage before connecting device)</li>
 	</ul>
 </section>
 
-<section>
-	<h2>Phase 4: Verification</h2>
-	<pre class="code">{`# Verify device is operational
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Phase 4: Verification</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Verify device is operational
 meshtastic --port /dev/ttyUSB0 --info
 
 # Set fixed position for infrastructure node
@@ -75,24 +75,12 @@ meshtastic --setlat 44.1003 --setlon -70.2148 --setalt 60
 ./tools/test/integration-tests.sh --port /dev/ttyUSB0`}</pre>
 </section>
 
-<section>
-	<h2>Phase 5: Monitoring</h2>
-	<ul>
-		<li>Check MQTT telemetry for battery voltage and uptime</li>
-		<li>Verify node appears in mesh node list</li>
-		<li>Schedule quarterly maintenance visits</li>
-		<li>Document site access procedures and emergency contacts</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Phase 5: Monitoring</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Check MQTT telemetry for battery voltage and uptime</li>
+		<li class="mb-1">Verify node appears in mesh node list</li>
+		<li class="mb-1">Schedule quarterly maintenance visits</li>
+		<li class="mb-1">Document site access procedures and emergency contacts</li>
 	</ul>
 </section>
-
-<style>
-	.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1rem; }
-	.breadcrumb a { color: #00d4aa; text-decoration: none; }
-	.intro { font-size: 1.1rem; color: #555; margin-bottom: 2rem; }
-	section { margin-bottom: 3rem; }
-	.code { background: #1a1a2e; color: #00d4aa; padding: 1.25rem; border-radius: 8px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
-	code { background: #f0f0f0; padding: 0.15rem 0.35rem; border-radius: 3px; font-size: 0.85rem; }
-	table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-	th, td { padding: 0.75rem; border: 1px solid #ddd; text-align: left; }
-	th { background: #f5f5f5; font-weight: 600; }
-</style>

--- a/site/src/routes/guides/solar-relay/+page.svelte
+++ b/site/src/routes/guides/solar-relay/+page.svelte
@@ -6,92 +6,92 @@
 	<title>Solar Relay Deployment - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Solar Relay Deployment
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Solar Relay Deployment
 </nav>
 
 <h1>Solar Relay Deployment</h1>
-<p class="intro">Panel sizing, battery calculations, weatherproofing, and seasonal maintenance for solar-powered Station G2 relay nodes at 44.1&deg;N latitude.</p>
+<p class="text-lg text-surface-400 mb-8">Panel sizing, battery calculations, weatherproofing, and seasonal maintenance for solar-powered Station G2 relay nodes at 44.1&deg;N latitude.</p>
 
-<section>
-	<h2>Power Budget</h2>
-	<table>
-		<thead><tr><th>Parameter</th><th>Value</th><th>Notes</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Power Budget</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Parameter</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Value</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Notes</th></tr></thead>
 		<tbody>
-			<tr><td>Station G2 power draw</td><td>~0.5 W average</td><td>TX bursts up to 1.5 W at 30 dBm</td></tr>
-			<tr><td>Daily energy</td><td>~12 Wh</td><td>0.5 W x 24 hours</td></tr>
-			<tr><td>Winter peak sun hours (44.1&deg;N)</td><td>~3 hours</td><td>December/January worst case</td></tr>
-			<tr><td>Summer peak sun hours</td><td>~5.5 hours</td><td>June/July</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Station G2 power draw</td><td class="p-3 text-surface-200 border-b border-surface-700">~0.5 W average</td><td class="p-3 text-surface-200 border-b border-surface-700">TX bursts up to 1.5 W at 30 dBm</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Daily energy</td><td class="p-3 text-surface-200 border-b border-surface-700">~12 Wh</td><td class="p-3 text-surface-200 border-b border-surface-700">0.5 W x 24 hours</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Winter peak sun hours (44.1&deg;N)</td><td class="p-3 text-surface-200 border-b border-surface-700">~3 hours</td><td class="p-3 text-surface-200 border-b border-surface-700">December/January worst case</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Summer peak sun hours</td><td class="p-3 text-surface-200 border-b border-surface-700">~5.5 hours</td><td class="p-3 text-surface-200 border-b border-surface-700">June/July</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Recommended Components</h2>
-	<table>
-		<thead><tr><th>Component</th><th>Minimum Spec</th><th>Recommended</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Recommended Components</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Component</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Minimum Spec</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Recommended</th></tr></thead>
 		<tbody>
-			<tr><td>Solar panel</td><td>10 W</td><td>20 W (winter headroom)</td></tr>
-			<tr><td>Battery</td><td>12 Ah LiFePO4 (12V)</td><td>20 Ah LiFePO4 (3+ days autonomy)</td></tr>
-			<tr><td>Charge controller</td><td>PWM 5A</td><td>MPPT 10A (better low-light performance)</td></tr>
-			<tr><td>Voltage regulator</td><td>12V to 5V USB-C buck converter</td><td>Rated 3A continuous</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Solar panel</td><td class="p-3 text-surface-200 border-b border-surface-700">10 W</td><td class="p-3 text-surface-200 border-b border-surface-700">20 W (winter headroom)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Battery</td><td class="p-3 text-surface-200 border-b border-surface-700">12 Ah LiFePO4 (12V)</td><td class="p-3 text-surface-200 border-b border-surface-700">20 Ah LiFePO4 (3+ days autonomy)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Charge controller</td><td class="p-3 text-surface-200 border-b border-surface-700">PWM 5A</td><td class="p-3 text-surface-200 border-b border-surface-700">MPPT 10A (better low-light performance)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Voltage regulator</td><td class="p-3 text-surface-200 border-b border-surface-700">12V to 5V USB-C buck converter</td><td class="p-3 text-surface-200 border-b border-surface-700">Rated 3A continuous</td></tr>
 		</tbody>
 	</table>
-	<p>Station G2 accepts 12V DC input directly -- use this instead of USB when available to avoid buck converter losses.</p>
+	<p class="text-surface-300 mb-4">Station G2 accepts 12V DC input directly -- use this instead of USB when available to avoid buck converter losses.</p>
 </section>
 
-<section>
-	<h2>Panel Mounting</h2>
-	<ul>
-		<li><strong>Tilt angle</strong>: Fixed at 44&deg; (equal to latitude) for year-round average</li>
-		<li><strong>Winter optimization</strong>: Tilt to 59&deg; (latitude + 15&deg;) for December-February</li>
-		<li><strong>Summer optimization</strong>: Tilt to 29&deg; (latitude - 15&deg;) for June-August</li>
-		<li><strong>Orientation</strong>: True south (not magnetic south -- ~14&deg; declination in Maine)</li>
-		<li><strong>Shading</strong>: No shading from 9 AM to 3 PM year-round</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Panel Mounting</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1"><strong>Tilt angle</strong>: Fixed at 44&deg; (equal to latitude) for year-round average</li>
+		<li class="mb-1"><strong>Winter optimization</strong>: Tilt to 59&deg; (latitude + 15&deg;) for December-February</li>
+		<li class="mb-1"><strong>Summer optimization</strong>: Tilt to 29&deg; (latitude - 15&deg;) for June-August</li>
+		<li class="mb-1"><strong>Orientation</strong>: True south (not magnetic south -- ~14&deg; declination in Maine)</li>
+		<li class="mb-1"><strong>Shading</strong>: No shading from 9 AM to 3 PM year-round</li>
 	</ul>
 </section>
 
-<section>
-	<h2>Weatherproofing</h2>
-	<ul>
-		<li>IP65+ enclosure for electronics (NEMA 4X rated for outdoor use)</li>
-		<li>Cable glands for all wire entry points -- seal with marine silicone</li>
-		<li>Drip loop on antenna cable to prevent water ingress at connector</li>
-		<li>Dielectric grease on all SMA connections</li>
-		<li>Desiccant packets inside enclosure (replace quarterly)</li>
-		<li>Mount enclosure on north side of pole/structure (minimize solar heating)</li>
-		<li>Ensure drainage holes at bottom of enclosure</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Weatherproofing</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">IP65+ enclosure for electronics (NEMA 4X rated for outdoor use)</li>
+		<li class="mb-1">Cable glands for all wire entry points -- seal with marine silicone</li>
+		<li class="mb-1">Drip loop on antenna cable to prevent water ingress at connector</li>
+		<li class="mb-1">Dielectric grease on all SMA connections</li>
+		<li class="mb-1">Desiccant packets inside enclosure (replace quarterly)</li>
+		<li class="mb-1">Mount enclosure on north side of pole/structure (minimize solar heating)</li>
+		<li class="mb-1">Ensure drainage holes at bottom of enclosure</li>
 	</ul>
 </section>
 
-<section>
-	<h2>Cable Routing</h2>
-	<ul>
-		<li>UV-resistant conduit for all external cable runs</li>
-		<li>Minimum bend radius: 5x cable diameter</li>
-		<li>Secure cables every 30 cm with UV-rated zip ties</li>
-		<li>Ground the antenna coax shield at the enclosure entry point</li>
-		<li>Use outdoor-rated LMR-400 coax for antenna runs over 3 m</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Cable Routing</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">UV-resistant conduit for all external cable runs</li>
+		<li class="mb-1">Minimum bend radius: 5x cable diameter</li>
+		<li class="mb-1">Secure cables every 30 cm with UV-rated zip ties</li>
+		<li class="mb-1">Ground the antenna coax shield at the enclosure entry point</li>
+		<li class="mb-1">Use outdoor-rated LMR-400 coax for antenna runs over 3 m</li>
 	</ul>
 </section>
 
-<section>
-	<h2>Maintenance Schedule</h2>
-	<table>
-		<thead><tr><th>Frequency</th><th>Task</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Maintenance Schedule</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Frequency</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Task</th></tr></thead>
 		<tbody>
-			<tr><td>Monthly</td><td>Check MQTT telemetry for battery voltage (should be 12.8-13.2V)</td></tr>
-			<tr><td>Quarterly</td><td>Visual inspection: panel, cables, enclosure seal, desiccant</td></tr>
-			<tr><td>Bi-annually</td><td>Clean panel surface, check SMA connections, verify antenna SWR</td></tr>
-			<tr><td>Annually</td><td>Replace desiccant, re-apply dielectric grease, check battery health</td></tr>
-			<tr><td>After storms</td><td>Inspect for physical damage, check antenna alignment</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Monthly</td><td class="p-3 text-surface-200 border-b border-surface-700">Check MQTT telemetry for battery voltage (should be 12.8-13.2V)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Quarterly</td><td class="p-3 text-surface-200 border-b border-surface-700">Visual inspection: panel, cables, enclosure seal, desiccant</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Bi-annually</td><td class="p-3 text-surface-200 border-b border-surface-700">Clean panel surface, check SMA connections, verify antenna SWR</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Annually</td><td class="p-3 text-surface-200 border-b border-surface-700">Replace desiccant, re-apply dielectric grease, check battery health</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">After storms</td><td class="p-3 text-surface-200 border-b border-surface-700">Inspect for physical damage, check antenna alignment</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Provisioning</h2>
-	<pre class="code">{`# Flash and configure before deployment
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Provisioning</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Flash and configure before deployment
 just provision station-g2 /dev/ttyUSB0
 
 # Set fixed GPS position (no GPS module needed for fixed relay)
@@ -99,17 +99,5 @@ meshtastic --setlat 44.1003 --setlon -70.2148 --setalt 60
 
 # Run bench test suite before deployment
 just test-integration /dev/ttyUSB0`}</pre>
-	<p>See <a href="{base}/guides/node-deployment">Node Deployment Guide</a> for full installation procedures.</p>
+	<p class="text-surface-300 mb-4">See <a href="{base}/guides/node-deployment" class="text-primary-400">Node Deployment Guide</a> for full installation procedures.</p>
 </section>
-
-<style>
-	.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1rem; }
-	.breadcrumb a { color: #00d4aa; text-decoration: none; }
-	.intro { font-size: 1.1rem; color: #555; margin-bottom: 2rem; }
-	section { margin-bottom: 3rem; }
-	.code { background: #1a1a2e; color: #00d4aa; padding: 1.25rem; border-radius: 8px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
-	table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-	th, td { padding: 0.75rem; border: 1px solid #ddd; text-align: left; }
-	th { background: #f5f5f5; font-weight: 600; }
-	a { color: #00d4aa; }
-</style>

--- a/site/src/routes/guides/stealth-mode/+page.svelte
+++ b/site/src/routes/guides/stealth-mode/+page.svelte
@@ -6,29 +6,29 @@
 	<title>Stealth Mode - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Stealth Mode
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Stealth Mode
 </nav>
 
 <h1>Stealth Mode: Minimizing RF Footprint</h1>
-<p class="intro">Configure a Meshtastic device for minimal RF visibility using CLIENT_HIDDEN mode.</p>
+<p class="text-lg text-surface-400 mb-8">Configure a Meshtastic device for minimal RF visibility using CLIENT_HIDDEN mode.</p>
 
-<section>
-	<h2>Device Roles Comparison</h2>
-	<table>
-		<thead><tr><th>Role</th><th>Node List</th><th>Broadcasts NodeInfo</th><th>Rebroadcasts</th><th>Sends Position</th></tr></thead>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Device Roles Comparison</h2>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Role</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Node List</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Broadcasts NodeInfo</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Rebroadcasts</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Sends Position</th></tr></thead>
 		<tbody>
-			<tr><td>ROUTER</td><td>Yes</td><td>Yes</td><td>Yes (all)</td><td>Yes</td></tr>
-			<tr><td>CLIENT</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
-			<tr><td>CLIENT_MUTE</td><td>Yes</td><td>Yes</td><td>No</td><td>Yes</td></tr>
-			<tr><td><strong>CLIENT_HIDDEN</strong></td><td><strong>No</strong></td><td><strong>No</strong></td><td><strong>No</strong></td><td><strong>No</strong></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">ROUTER</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes (all)</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">CLIENT</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">CLIENT_MUTE</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td><td class="p-3 text-surface-200 border-b border-surface-700">No</td><td class="p-3 text-surface-200 border-b border-surface-700">Yes</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700"><strong>CLIENT_HIDDEN</strong></td><td class="p-3 text-surface-200 border-b border-surface-700"><strong>No</strong></td><td class="p-3 text-surface-200 border-b border-surface-700"><strong>No</strong></td><td class="p-3 text-surface-200 border-b border-surface-700"><strong>No</strong></td><td class="p-3 text-surface-200 border-b border-surface-700"><strong>No</strong></td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Enable CLIENT_HIDDEN</h2>
-	<pre class="code">{`# Set role to CLIENT_HIDDEN
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Enable CLIENT_HIDDEN</h2>
+	<pre class="bg-surface-800 text-primary-400 p-5 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono">{`# Set role to CLIENT_HIDDEN
 meshtastic --set device.role CLIENT_HIDDEN
 
 # Disable GPS position broadcast
@@ -39,45 +39,34 @@ meshtastic --set position.fixed_position false
 meshtastic --set device.nodeinfo_broadcast_secs 0`}</pre>
 </section>
 
-<section>
-	<h2>What CLIENT_HIDDEN Does</h2>
-	<ul>
-		<li>Device does not appear in other nodes' node lists</li>
-		<li>Does not broadcast periodic NodeInfo packets</li>
-		<li>Does not rebroadcast other nodes' messages</li>
-		<li>Does not share GPS position</li>
-		<li>Can still send and receive messages normally</li>
-		<li>Can still use PKC for encrypted DMs</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">What CLIENT_HIDDEN Does</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Device does not appear in other nodes' node lists</li>
+		<li class="mb-1">Does not broadcast periodic NodeInfo packets</li>
+		<li class="mb-1">Does not rebroadcast other nodes' messages</li>
+		<li class="mb-1">Does not share GPS position</li>
+		<li class="mb-1">Can still send and receive messages normally</li>
+		<li class="mb-1">Can still use PKC for encrypted DMs</li>
 	</ul>
 </section>
 
-<section>
-	<h2>Limitations</h2>
-	<ul>
-		<li>When you <em>send</em> a message, your transmission is still detectable via SDR</li>
-		<li>Your device's radio address is visible in packet headers (encrypted payload, but address is plain)</li>
-		<li>Does not protect against traffic analysis or direction finding</li>
-		<li>Reduces mesh resilience (hidden nodes don't relay)</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Limitations</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">When you <em>send</em> a message, your transmission is still detectable via SDR</li>
+		<li class="mb-1">Your device's radio address is visible in packet headers (encrypted payload, but address is plain)</li>
+		<li class="mb-1">Does not protect against traffic analysis or direction finding</li>
+		<li class="mb-1">Reduces mesh resilience (hidden nodes don't relay)</li>
 	</ul>
 </section>
 
-<section>
-	<h2>When to Use</h2>
-	<ul>
-		<li>Situations requiring location privacy</li>
-		<li>Operating in areas with potential surveillance</li>
-		<li>Personal preference for minimal network footprint</li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">When to Use</h2>
+	<ul class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Situations requiring location privacy</li>
+		<li class="mb-1">Operating in areas with potential surveillance</li>
+		<li class="mb-1">Personal preference for minimal network footprint</li>
 	</ul>
-	<p>For maximum operational security, combine with <a href="{base}/curriculum/tails">TAILS OS</a> and air-gapped workflows.</p>
+	<p class="text-surface-300 mb-4">For maximum operational security, combine with <a href="{base}/curriculum/tails" class="text-primary-400">TAILS OS</a> and air-gapped workflows.</p>
 </section>
-
-<style>
-	.breadcrumb { font-size: 0.85rem; color: #888; margin-bottom: 1rem; }
-	.breadcrumb a { color: #00d4aa; text-decoration: none; }
-	.intro { font-size: 1.1rem; color: #555; margin-bottom: 2rem; }
-	section { margin-bottom: 3rem; }
-	.code { background: #1a1a2e; color: #00d4aa; padding: 1.25rem; border-radius: 8px; overflow-x: auto; font-size: 0.85rem; line-height: 1.5; }
-	table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-	th, td { padding: 0.75rem; border: 1px solid #ddd; text-align: left; }
-	th { background: #f5f5f5; font-weight: 600; }
-</style>

--- a/site/src/routes/guides/troubleshooting/+page.svelte
+++ b/site/src/routes/guides/troubleshooting/+page.svelte
@@ -6,196 +6,132 @@
 	<title>Troubleshooting - LA-Mesh</title>
 </svelte:head>
 
-<nav class="breadcrumb">
-	<a href="{base}/guides">Guides</a> / Troubleshooting
+<nav class="text-sm text-surface-500 mb-4">
+	<a href="{base}/guides" class="text-primary-400 no-underline">Guides</a> / Troubleshooting
 </nav>
 
 <h1>Troubleshooting Guide</h1>
-<p class="intro">Common issues and solutions for LA-Mesh devices and network.</p>
+<p class="text-lg text-surface-400 mb-8">Common issues and solutions for LA-Mesh devices and network.</p>
 
-<section>
-	<h2>Device Issues</h2>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Device Issues</h2>
 
-	<h3>Device won't power on</h3>
-	<table>
-		<thead><tr><th>Check</th><th>Action</th></tr></thead>
+	<h3 class="text-surface-100 mt-8">Device won't power on</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Check</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th></tr></thead>
 		<tbody>
-			<tr><td>Battery dead</td><td>Charge for at least 30 minutes via USB-C</td></tr>
-			<tr><td>Stuck state</td><td>Hold power button for 10+ seconds to force restart</td></tr>
-			<tr><td>Hardware failure</td><td>Try a different USB cable, check for physical damage</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Battery dead</td><td class="p-3 text-surface-200 border-b border-surface-700">Charge for at least 30 minutes via USB-C</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Stuck state</td><td class="p-3 text-surface-200 border-b border-surface-700">Hold power button for 10+ seconds to force restart</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Hardware failure</td><td class="p-3 text-surface-200 border-b border-surface-700">Try a different USB cable, check for physical damage</td></tr>
 		</tbody>
 	</table>
 
-	<h3>Device not detected on USB</h3>
-	<table>
-		<thead><tr><th>Check</th><th>Action</th></tr></thead>
+	<h3 class="text-surface-100 mt-8">Device not detected on USB</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Check</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th></tr></thead>
 		<tbody>
-			<tr><td>Cable is charge-only</td><td>Use a data-capable USB-C cable</td></tr>
-			<tr><td>Wrong driver</td><td>ESP32-S3 uses built-in USB, CP2102/CH340 for older chips</td></tr>
-			<tr><td>Port in use</td><td>Close other serial monitors, check <code>ls /dev/ttyUSB* /dev/ttyACM*</code></td></tr>
-			<tr><td>Bootloader mode needed</td><td>Hold BOOT, press RESET, release BOOT</td></tr>
-		</tbody>
-	</table>
-</section>
-
-<section>
-	<h2>Network Issues</h2>
-
-	<h3>Can't see other nodes</h3>
-	<table>
-		<thead><tr><th>Check</th><th>Action</th></tr></thead>
-		<tbody>
-			<tr><td>Wrong channel PSK</td><td>Verify PSK matches: <code>meshtastic --info</code></td></tr>
-			<tr><td>Wrong region</td><td>Must be set to <code>US</code>: <code>meshtastic --set lora.region US</code></td></tr>
-			<tr><td>Wrong modem preset</td><td>Must match network: <code>meshtastic --set lora.modem_preset LONG_FAST</code></td></tr>
-			<tr><td>Out of range</td><td>Move closer to a known node, check antenna</td></tr>
-			<tr><td>Antenna disconnected</td><td>Verify antenna is firmly connected to SMA port</td></tr>
-		</tbody>
-	</table>
-
-	<h3>Messages not delivering</h3>
-	<table>
-		<thead><tr><th>Check</th><th>Action</th></tr></thead>
-		<tbody>
-			<tr><td>Hop limit too low</td><td>Should be 5 for LA-Mesh (check: <code>meshtastic --info</code>)</td></tr>
-			<tr><td>Airtime exhausted</td><td>Wait a few minutes (device enforces duty cycle limits)</td></tr>
-			<tr><td>Channel congestion</td><td>Too many nodes transmitting; reduce message frequency</td></tr>
-			<tr><td>Device role wrong</td><td>ROUTER nodes should have <code>rebroadcast_mode: ALL</code></td></tr>
-		</tbody>
-	</table>
-
-	<h3>Poor signal quality (low SNR)</h3>
-	<table>
-		<thead><tr><th>Action</th><th>Expected Improvement</th></tr></thead>
-		<tbody>
-			<tr><td>Move to open area</td><td>+10-20 dB</td></tr>
-			<tr><td>Raise antenna height</td><td>+3-6 dB per doubling of height</td></tr>
-			<tr><td>Use external antenna</td><td>+3-10 dB over stock whip</td></tr>
-			<tr><td>Reduce distance</td><td>+6 dB per halving of distance</td></tr>
-			<tr><td>Clear obstructions</td><td>Trees: -3 to -10 dB, Buildings: -10 to -30 dB</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Cable is charge-only</td><td class="p-3 text-surface-200 border-b border-surface-700">Use a data-capable USB-C cable</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Wrong driver</td><td class="p-3 text-surface-200 border-b border-surface-700">ESP32-S3 uses built-in USB, CP2102/CH340 for older chips</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Port in use</td><td class="p-3 text-surface-200 border-b border-surface-700">Close other serial monitors, check <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">ls /dev/ttyUSB* /dev/ttyACM*</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Bootloader mode needed</td><td class="p-3 text-surface-200 border-b border-surface-700">Hold BOOT, press RESET, release BOOT</td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Firmware Issues</h2>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Network Issues</h2>
 
-	<h3>Flash fails</h3>
-	<table>
-		<thead><tr><th>Error</th><th>Solution</th></tr></thead>
+	<h3 class="text-surface-100 mt-8">Can't see other nodes</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Check</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th></tr></thead>
 		<tbody>
-			<tr><td>"Failed to connect"</td><td>Enter bootloader mode (BOOT + RESET)</td></tr>
-			<tr><td>"Invalid head of packet"</td><td>Erase flash first: <code>just flash-erase</code></td></tr>
-			<tr><td>"Timed out"</td><td>Try lower baud rate (115200 instead of 921600)</td></tr>
-			<tr><td>Permission denied</td><td><code>sudo usermod -aG dialout $USER</code> (re-login)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Wrong channel PSK</td><td class="p-3 text-surface-200 border-b border-surface-700">Verify PSK matches: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">meshtastic --info</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Wrong region</td><td class="p-3 text-surface-200 border-b border-surface-700">Must be set to <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">US</code>: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">meshtastic --set lora.region US</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Wrong modem preset</td><td class="p-3 text-surface-200 border-b border-surface-700">Must match network: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">meshtastic --set lora.modem_preset LONG_FAST</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Out of range</td><td class="p-3 text-surface-200 border-b border-surface-700">Move closer to a known node, check antenna</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Antenna disconnected</td><td class="p-3 text-surface-200 border-b border-surface-700">Verify antenna is firmly connected to SMA port</td></tr>
 		</tbody>
 	</table>
 
-	<h3>Device stuck in boot loop</h3>
-	<ol>
-		<li>Enter bootloader mode (BOOT + RESET)</li>
-		<li>Erase flash: <code>just flash-erase</code></li>
-		<li>Re-flash firmware: <code>just flash-meshtastic firmware.bin</code></li>
-		<li>Re-apply configuration profile</li>
+	<h3 class="text-surface-100 mt-8">Messages not delivering</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Check</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th></tr></thead>
+		<tbody>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Hop limit too low</td><td class="p-3 text-surface-200 border-b border-surface-700">Should be 5 for LA-Mesh (check: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">meshtastic --info</code>)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Airtime exhausted</td><td class="p-3 text-surface-200 border-b border-surface-700">Wait a few minutes (device enforces duty cycle limits)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Channel congestion</td><td class="p-3 text-surface-200 border-b border-surface-700">Too many nodes transmitting; reduce message frequency</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Device role wrong</td><td class="p-3 text-surface-200 border-b border-surface-700">ROUTER nodes should have <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">rebroadcast_mode: ALL</code></td></tr>
+		</tbody>
+	</table>
+
+	<h3 class="text-surface-100 mt-8">Poor signal quality (low SNR)</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Expected Improvement</th></tr></thead>
+		<tbody>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Move to open area</td><td class="p-3 text-surface-200 border-b border-surface-700">+10-20 dB</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Raise antenna height</td><td class="p-3 text-surface-200 border-b border-surface-700">+3-6 dB per doubling of height</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Use external antenna</td><td class="p-3 text-surface-200 border-b border-surface-700">+3-10 dB over stock whip</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Reduce distance</td><td class="p-3 text-surface-200 border-b border-surface-700">+6 dB per halving of distance</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Clear obstructions</td><td class="p-3 text-surface-200 border-b border-surface-700">Trees: -3 to -10 dB, Buildings: -10 to -30 dB</td></tr>
+		</tbody>
+	</table>
+</section>
+
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Firmware Issues</h2>
+
+	<h3 class="text-surface-100 mt-8">Flash fails</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Error</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Solution</th></tr></thead>
+		<tbody>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">"Failed to connect"</td><td class="p-3 text-surface-200 border-b border-surface-700">Enter bootloader mode (BOOT + RESET)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">"Invalid head of packet"</td><td class="p-3 text-surface-200 border-b border-surface-700">Erase flash first: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just flash-erase</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">"Timed out"</td><td class="p-3 text-surface-200 border-b border-surface-700">Try lower baud rate (115200 instead of 921600)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Permission denied</td><td class="p-3 text-surface-200 border-b border-surface-700"><code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">sudo usermod -aG dialout $USER</code> (re-login)</td></tr>
+		</tbody>
+	</table>
+
+	<h3 class="text-surface-100 mt-8">Device stuck in boot loop</h3>
+	<ol class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Enter bootloader mode (BOOT + RESET)</li>
+		<li class="mb-1">Erase flash: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just flash-erase</code></li>
+		<li class="mb-1">Re-flash firmware: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">just flash-meshtastic firmware.bin</code></li>
+		<li class="mb-1">Re-apply configuration profile</li>
 	</ol>
 </section>
 
-<section>
-	<h2>Bridge Issues</h2>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Bridge Issues</h2>
 
-	<h3>SMS bridge not sending</h3>
-	<table>
-		<thead><tr><th>Check</th><th>Action</th></tr></thead>
+	<h3 class="text-surface-100 mt-8">SMS bridge not sending</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Check</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th></tr></thead>
 		<tbody>
-			<tr><td>SMS gateway credentials</td><td>Verify in operator keystore</td></tr>
-			<tr><td>MQTT connection</td><td>Check: <code>systemctl status mosquitto</code></td></tr>
-			<tr><td>Bridge running</td><td>Check: <code>systemctl status lamesh-sms-bridge</code></td></tr>
-			<tr><td>Phone format</td><td>Must be E.164: <code>+12075551234</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">SMS gateway credentials</td><td class="p-3 text-surface-200 border-b border-surface-700">Verify in operator keystore</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">MQTT connection</td><td class="p-3 text-surface-200 border-b border-surface-700">Check: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">systemctl status mosquitto</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Bridge running</td><td class="p-3 text-surface-200 border-b border-surface-700">Check: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">systemctl status lamesh-sms-bridge</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Phone format</td><td class="p-3 text-surface-200 border-b border-surface-700">Must be E.164: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">+12075551234</code></td></tr>
 		</tbody>
 	</table>
 
-	<h3>MQTT not receiving mesh messages</h3>
-	<table>
-		<thead><tr><th>Check</th><th>Action</th></tr></thead>
+	<h3 class="text-surface-100 mt-8">MQTT not receiving mesh messages</h3>
+	<table class="w-full border-collapse mt-4">
+		<thead><tr><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Check</th><th class="bg-surface-800 text-surface-300 p-3 text-left text-xs uppercase tracking-wider">Action</th></tr></thead>
 		<tbody>
-			<tr><td>meshtasticd running</td><td>Check: <code>systemctl status meshtasticd</code></td></tr>
-			<tr><td>MQTT enabled on device</td><td>Verify: <code>meshtastic --info</code> (MQTT section)</td></tr>
-			<tr><td>Topic mismatch</td><td>Default: <code>msh/US/2/json/LongFast/+</code></td></tr>
-			<tr><td>Mosquitto running</td><td>Check: <code>systemctl status mosquitto</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">meshtasticd running</td><td class="p-3 text-surface-200 border-b border-surface-700">Check: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">systemctl status meshtasticd</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">MQTT enabled on device</td><td class="p-3 text-surface-200 border-b border-surface-700">Verify: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">meshtastic --info</code> (MQTT section)</td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Topic mismatch</td><td class="p-3 text-surface-200 border-b border-surface-700">Default: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">msh/US/2/json/LongFast/+</code></td></tr>
+			<tr><td class="p-3 text-surface-200 border-b border-surface-700">Mosquitto running</td><td class="p-3 text-surface-200 border-b border-surface-700">Check: <code class="font-mono text-primary-400 bg-surface-800 px-1.5 py-0.5 rounded text-sm">systemctl status mosquitto</code></td></tr>
 		</tbody>
 	</table>
 </section>
 
-<section>
-	<h2>Getting Help</h2>
-	<ol>
-		<li>Check this troubleshooting guide</li>
-		<li>Check <a href="https://meshtastic.org/docs/">Meshtastic documentation</a></li>
-		<li>Ask at a community meetup</li>
-		<li>Open an issue: <a href="https://github.com/Jesssullivan/LA-Mesh/issues">GitHub Issues</a></li>
+<section class="mb-12">
+	<h2 class="text-2xl font-bold text-surface-50 mb-4">Getting Help</h2>
+	<ol class="text-surface-300 pl-6 mb-4">
+		<li class="mb-1">Check this troubleshooting guide</li>
+		<li class="mb-1">Check <a href="https://meshtastic.org/docs/" class="text-primary-400">Meshtastic documentation</a></li>
+		<li class="mb-1">Ask at a community meetup</li>
+		<li class="mb-1">Open an issue: <a href="https://github.com/Jesssullivan/LA-Mesh/issues" class="text-primary-400">GitHub Issues</a></li>
 	</ol>
 </section>
-
-<style>
-	.breadcrumb {
-		font-size: 0.85rem;
-		color: #888;
-		margin-bottom: 1rem;
-	}
-
-	.breadcrumb a {
-		color: #00d4aa;
-		text-decoration: none;
-	}
-
-	.intro {
-		font-size: 1.1rem;
-		color: #555;
-		margin-bottom: 2rem;
-	}
-
-	section {
-		margin-bottom: 3rem;
-	}
-
-	h3 {
-		margin-top: 2rem;
-	}
-
-	table {
-		width: 100%;
-		border-collapse: collapse;
-		margin-top: 0.5rem;
-		margin-bottom: 1rem;
-	}
-
-	th, td {
-		padding: 0.75rem;
-		border: 1px solid #ddd;
-		text-align: left;
-	}
-
-	th {
-		background: #f5f5f5;
-		font-weight: 600;
-	}
-
-	code {
-		background: #f0f0f0;
-		padding: 0.15rem 0.35rem;
-		border-radius: 3px;
-		font-size: 0.85rem;
-	}
-
-	a {
-		color: #00d4aa;
-	}
-
-	ol {
-		padding-left: 1.5rem;
-	}
-
-	li {
-		margin-bottom: 0.5rem;
-	}
-</style>

--- a/site/svelte.config.js
+++ b/site/svelte.config.js
@@ -1,12 +1,39 @@
 import adapter from '@sveltejs/adapter-static';
-import { mdsvex } from 'mdsvex';
+import { mdsvex, escapeSvelte } from 'mdsvex';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { createHighlighter } from 'shiki';
+import remarkGfm from 'remark-gfm';
+import rehypeSlug from 'rehype-slug';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeExternalLinks from 'rehype-external-links';
 
 const basePath = process.env.DOCS_BASE_PATH || '';
 
+const highlighter = await createHighlighter({
+	themes: ['github-dark-default'],
+	langs: ['bash', 'json', 'yaml', 'toml', 'javascript', 'typescript', 'svelte', 'css', 'html', 'python', 'shell']
+});
+
 /** @type {import('mdsvex').MdsvexOptions} */
 const mdsvexOptions = {
-	extensions: ['.md', '.svx']
+	extensions: ['.md', '.svx'],
+	remarkPlugins: [remarkGfm],
+	rehypePlugins: [
+		rehypeSlug,
+		[rehypeAutolinkHeadings, { behavior: 'wrap' }],
+		[rehypeExternalLinks, { target: '_blank' }]
+	],
+	highlight: {
+		highlighter: (code, lang) => {
+			const html = escapeSvelte(
+				highlighter.codeToHtml(code, {
+					lang: lang || 'text',
+					theme: 'github-dark-default'
+				})
+			);
+			return `{@html \`${html}\`}`;
+		}
+	}
 };
 
 /** @type {import('@sveltejs/kit').Config} */

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,6 +1,33 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import tailwindcss from '@tailwindcss/vite';
+import type { Plugin } from 'vite';
+
+// Skeleton-Tailwind v4 compatibility plugin (established pattern from tinyland.dev/MassageIthaca)
+function skeletonTailwindV4Compat(): Plugin {
+	return {
+		name: 'skeleton-tailwind-v4-compat',
+		enforce: 'pre',
+		transform(code, id) {
+			if (id.includes('@skeletonlabs/skeleton') && id.endsWith('.css')) {
+				code = code
+					.replace(/@variant\s+sm\s*{/g, '@media (min-width: 640px) {')
+					.replace(/@variant\s+md\s*{/g, '@media (min-width: 768px) {')
+					.replace(/@variant\s+lg\s*{/g, '@media (min-width: 1024px) {')
+					.replace(/@variant\s+xl\s*{/g, '@media (min-width: 1280px) {')
+					.replace(/@variant\s+2xl\s*{/g, '@media (min-width: 1536px) {')
+					.replace(/@variant\s+dark\s*{/g, '.dark & {')
+					.replace(/@apply\s+variant-/g, '@apply ');
+				return { code, map: null };
+			}
+		}
+	};
+}
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [
+		skeletonTailwindV4Compat(),
+		tailwindcss(),
+		sveltekit()
+	]
 });


### PR DESCRIPTION
## Summary
- Migrate docs site from scoped CSS light theme to Skeleton UI v4.12 + Tailwind v4 + rolldown-vite dark terminal aesthetic
- Add Shiki syntax highlighting, StatusBadge component, redesigned home page with CI badges and justfile quick reference
- Restyle all 28 pages (home, devices, architecture, guides index, 12 guide pages, curriculum) to dark terminus theme
- Fix firmware build by adding missing `USERPREFS_RINGTONE_RTTTL` define

## Test plan
- [x] `pnpm check` passes (0 errors verified locally)
- [x] `pnpm build` produces 23 static HTML pages
- [ ] CI workflows (build-firmware, deploy-pages, ci) pass
- [x] All pages render with dark terminus theme
- [x] Mermaid diagrams render with dark palette on architecture page
- [x] Giscus comments load with matching dark theme
- [x] Code blocks use Shiki github-dark-default highlighting
- [ ] Mobile responsive layout works